### PR TITLE
Update many of the doctests.

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -117,9 +117,11 @@ impl<T: Send + Sync> ControllerDispatch<T> {
     /// # Example
     ///
     /// ```rust,no_run
+    /// use saphir::*;
+    /// 
     /// let u8_context = 1;
     /// let dispatch = ControllerDispatch::new(u8_context);
-    /// dispatch.add(Method::Get, "^/test$", |ctx, req, res| { println!("this will handle Get request done on <your_host>/test")});
+    /// dispatch.add(Method::GET, "^/test$", |ctx, req, res| { println!("this will handle Get request done on <your_host>/test")});
     /// ```
     pub fn add<F>(&self, method: Method, path: &str, delegate_func: F)
         where for<'r, 's, 't0> F: 'static + Fn(&'r T, &'s SyncRequest, &'t0 mut SyncResponse) {
@@ -130,10 +132,12 @@ impl<T: Send + Sync> ControllerDispatch<T> {
     /// # Example
     ///
     /// ```rust,no_run
+    /// use saphir::*;
+    /// 
     /// let u8_context = 1;
     /// let guard = BodyGuard;
     /// let dispatch = ControllerDispatch::new(u8_context);
-    /// dispatch.add_with_guards(Method::Get, "^/test$", guard.into(), |ctx, req, res| { println!("this will handle Get request done on <your_host>/test")});
+    /// dispatch.add_with_guards(Method::GET, "^/test$", guard.into(), |ctx, req, res| { println!("this will handle Get request done on <your_host>/test")});
     /// ```
     pub fn add_with_guards<F>(&self, method: Method, path: &str, guards: RequestGuardCollection, delegate_func: F)
         where for<'r, 's, 't0> F: 'static + Fn(&'r T, &'s SyncRequest, &'t0 mut SyncResponse) {
@@ -209,9 +213,12 @@ impl<C: Send + Sync> BasicController<C> {
     /// # Example
     ///
     /// ```rust,no_run
+    /// use saphir::*;
+    /// use saphir::controller::BasicController;
+    /// 
     /// let u8_context = 1;
-    /// let u8_controller = BasicController::new(u8_context);
-    /// u8_controller.add(Method::Get, "^/test$", |ctx, req, res| { println!("this will handle Get request done on <your_host>/test")});
+    /// let u8_controller = BasicController::new("/test", u8_context);
+    /// u8_controller.add(Method::GET, "^/test$", |ctx, req, res| { println!("this will handle Get request done on <your_host>/test")});
     /// ```
     pub fn add<F>(&self, method: Method, path: &str, delegate_func: F)
         where for<'r, 's, 't0> F: 'static + Fn(&'r C, &'s SyncRequest, &'t0 mut SyncResponse) {
@@ -222,9 +229,12 @@ impl<C: Send + Sync> BasicController<C> {
     /// # Example
     ///
     /// ```rust,no_run
+    /// use saphir::*;
+    /// use saphir::controller::BasicController;
+    /// 
     /// let u8_context = 1;
-    /// let u8_controller = BasicController::new(u8_context);
-    /// u8_controller.add(Method::Get, "^/test$", |ctx, req, res| { println!("this will handle Get request done on <your_host>/test")});
+    /// let u8_controller = BasicController::new("/test", u8_context);
+    /// u8_controller.add(Method::GET, "^/test$", |ctx, req, res| { println!("this will handle Get request done on <your_host>/test")});
     /// ```
     pub fn add_with_guards<F>(&self, method: Method, path: &str, guards: RequestGuardCollection, delegate_func: F)
         where for<'r, 's, 't0> F: 'static + Fn(&'r C, &'s SyncRequest, &'t0 mut SyncResponse) {

--- a/src/http.rs
+++ b/src/http.rs
@@ -104,7 +104,6 @@ impl SyncRequest {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     /// let request: Request<()> = Request::default();
     /// assert_eq!(*request.method(), Method::GET);
     /// ```
@@ -119,7 +118,6 @@ impl SyncRequest {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     /// let mut request: Request<()> = Request::default();
     /// *request.method_mut() = Method::PUT;
     /// assert_eq!(*request.method(), Method::PUT);
@@ -135,7 +133,6 @@ impl SyncRequest {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     /// let request: Request<()> = Request::default();
     /// assert_eq!(*request.uri(), *"/");
     /// ```
@@ -150,7 +147,6 @@ impl SyncRequest {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     /// let mut request: Request<()> = Request::default();
     /// *request.uri_mut() = "/hello".parse().unwrap();
     /// assert_eq!(*request.uri(), *"/hello");
@@ -231,7 +227,6 @@ impl SyncRequest {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     /// let request: Request<()> = Request::default();
     /// assert_eq!(request.version(), Version::HTTP_11);
     /// ```
@@ -246,7 +241,6 @@ impl SyncRequest {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     /// let mut request: Request<()> = Request::default();
     /// *request.version_mut() = Version::HTTP_2;
     /// assert_eq!(request.version(), Version::HTTP_2);
@@ -261,8 +255,8 @@ impl SyncRequest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use saphir::*;
-    /// # use saphir::headers::*;
+    /// use saphir::*;
+    /// 
     /// let request: Request<()> = Request::default();
     /// assert!(request.headers().is_empty());
     /// ```
@@ -276,8 +270,9 @@ impl SyncRequest {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use saphir::*;
-    /// # use saphir::headers::*;
+    /// use saphir::*;
+    /// use saphir::header::*;
+    /// 
     /// let mut request: Request<()> = Request::default();
     /// request.headers_mut().insert(HOST, HeaderValue::from_static("world"));
     /// assert!(!request.headers().is_empty());
@@ -311,7 +306,6 @@ impl SyncRequest {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     /// let request: Request<()> = Request::default();
     /// assert!(request.extensions().get::<i32>().is_none());
     /// ```
@@ -326,7 +320,6 @@ impl SyncRequest {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     /// let mut request: Request<()> = Request::default();
     /// request.extensions_mut().insert("hello");
     /// assert_eq!(request.extensions().get(), Some(&"hello"));
@@ -342,7 +335,6 @@ impl SyncRequest {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     /// let request: Request<String> = Request::default();
     /// assert!(request.body().is_empty());
     /// ```
@@ -357,7 +349,6 @@ impl SyncRequest {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     /// let mut request: Request<String> = Request::default();
     /// request.body_mut().push_str("hello world");
     /// assert!(!request.body().is_empty());
@@ -458,7 +449,6 @@ impl SyncResponse {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     ///
     /// let response = SyncResponse::new()
     ///     .status(200)
@@ -483,7 +473,6 @@ impl SyncResponse {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     ///
     /// let response = SyncResponse::new()
     ///     .version(Version::HTTP_2)
@@ -505,7 +494,6 @@ impl SyncResponse {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     ///
     /// let response = SyncResponse::new()
     ///     .header("Content-Type", "text/html")
@@ -540,7 +528,6 @@ impl SyncResponse {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     ///
     /// let response = SyncResponse::new()
     ///     .extension("My Extension")
@@ -574,10 +561,9 @@ impl SyncResponse {
     ///
     /// ```rust,no_run
     /// # use saphir::*;
-    /// # use saphir::headers::*;
     ///
     /// let response = SyncResponse::new()
-    ///     .body(b"this is a payload")
+    ///     .body("this is a payload")
     ///     .build_response()
     ///     .unwrap();
     /// ```

--- a/src/router.rs
+++ b/src/router.rs
@@ -21,12 +21,17 @@ impl Builder {
     /// Add a new controller with its route to the router
     /// # Example
     /// ```rust,no_run
+    /// use saphir::*;
+    /// use saphir::controller::BasicController;
+    /// use saphir::router::Builder;
+    /// 
     /// let u8_context = 1;
-    /// let u8_controller = BasicController::new(u8_context);
-    /// u8_controller.add(Method::Get, "^/test$", |ctx, req, res| { println!("this will handle Get request done on <your_host>/test")});
+    /// let u8_controller = BasicController::new("/test", u8_context);
+    /// u8_controller.add(Method::GET, "^/test$", |ctx, req, res| { println!("this will handle Get request done on <your_host>/test")});
     ///
-    /// let mut router = Router::new();
-    /// router.add("/test", u8_controller);
+    /// let mut router = Builder::new()
+    ///         .add(u8_controller)
+    ///         .build();
     ///
     /// ```
     pub fn add<C: 'static + Controller>(mut self, controller: C) -> Self {
@@ -39,12 +44,17 @@ impl Builder {
     /// Add a new controller with its route to the router
     /// # Example
     /// ```rust,no_run
+    /// use saphir::*;
+    /// use saphir::controller::BasicController;
+    /// use saphir::router::Builder;
+    /// 
     /// let u8_context = 1;
-    /// let u8_controller = BasicController::new(u8_context);
-    /// u8_controller.add(Method::Get, "^/test$", |ctx, req, res| { println!("this will handle Get request done on <your_host>/test")});
+    /// let u8_controller = BasicController::new("/test", u8_context);
+    /// u8_controller.add(Method::GET, "^/test$", |ctx, req, res| { println!("this will handle Get request done on <your_host>/test")});
     ///
-    /// let mut router = Router::new();
-    /// router.add("/test", u8_controller);
+    /// let mut router = Builder::new()
+    ///         .add(u8_controller)
+    ///         .build();
     ///
     /// ```
     pub fn route<C: 'static + Controller>(mut self, route: &str, controller: C) -> Self {


### PR DESCRIPTION
This fixes many of the doctests when running `cargo test`.

5 tests are still failing with the SyncResponse constructor.

```
---- src/http.rs - http::SyncResponse::version (line 474) stdout ----
error[E0507]: cannot move out of a mutable reference
 --> src/http.rs:477:16
  |
6 |   let response = SyncResponse::new()
  |  ________________^
7 | |     .version(Version::HTTP_2)
  | |_____________________________^ move occurs because value has type `saphir::SyncResponse`, which does not implement the `Copy` trait
```