### PR TITLE
Add getter for head in SyncRequest

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -98,6 +98,12 @@ impl SyncRequest {
         }
     }
 
+    /// Returns a reference to this request head.
+    #[inline]
+    pub fn head(&self) -> &ReqParts {
+        &self.head
+    }
+
     /// Returns a reference to the associated HTTP method.
     ///
     /// # Examples


### PR DESCRIPTION
I have I use case when accessing the underlying request parts of the http crate would be useful to avoid code duplication and wrapping struct. If there is a deeper reason to not let user access this, feel free to close.