### PR TITLE
Initial implementation & Macro support for Multipart FormData

### DIFF
--- a/saphir/Cargo.toml
+++ b/saphir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saphir"
-version = "2.0.2"
+version = "2.1.0"
 edition = "2018"
 authors = ["Richer Archambault <richer.arc@gmail.com>"]
 description = "Fully async-await http server framework"
@@ -12,16 +12,17 @@ keywords = ["hyper", "http", "server", "web", "async"]
 license = "MIT"
 
 [features]
-default = ["macro"]
+default = ["macro", "multipart"]
 full = ["macro", "json", "form", "https"]
 https = ["base64", "rustls", "tokio-rustls"]
 json = ["serde", "serde_json"]
 form = ["serde", "serde_urlencoded"]
 macro = ["saphir_macro"]
+multipart = ["mime", "nom"]
 
 [dependencies]
 log = "0.4"
-hyper = "0.13"
+hyper = { version = "0.13", features = ["stream"] }
 tokio = { version = "0.2", features = ["full"] }
 futures = "0.3"
 futures-util = "0.3"
@@ -37,10 +38,13 @@ base64 = { version = "0.11", optional = true }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 serde_urlencoded = { version = "0.6", optional = true }
-saphir_macro = { path = "../saphir_macro", version = "1.0.0", optional = true}
+saphir_macro = { path = "../saphir_macro", version = "1.1.0", optional = true}
+mime = { version = "0.3", optional = true }
+nom = { version = "5", optional = true }
 
 [dev-dependencies]
 tokio-timer = "0.2.13"
 env_logger = "0.7"
 serde = "1.0"
 serde_derive = "1.0"
+mime = "0.3"

--- a/saphir/examples/macro.rs
+++ b/saphir/examples/macro.rs
@@ -53,11 +53,11 @@ impl UserController {
     }
 
     #[post("/multi")]
-    async fn multipart(&self, mut mul: Multipart) -> (u16, String) {
+    async fn multipart(&self, mul: Multipart) -> (u16, String) {
         let mut multipart_image_count = 0;
         while let Ok(Some(mut f)) = mul.next_field().await {
             if f.content_type() == &mime::IMAGE_PNG {
-                f.save(format!("/tmp/{}.png", f.name())).await;
+                let _ = f.save(format!("/tmp/{}.png", f.name())).await;
                 multipart_image_count += 1;
             }
         }

--- a/saphir/examples/macro.rs
+++ b/saphir/examples/macro.rs
@@ -1,5 +1,6 @@
-use saphir::prelude::*;
 use serde_derive::{Deserialize, Serialize};
+
+use saphir::prelude::*;
 
 fn guard_string(_controller: &UserController) -> String {
     UserController::BASE_PATH.to_string()
@@ -49,6 +50,19 @@ impl UserController {
     #[guard(fn = "print_string_guard", data = "guard_string")]
     async fn list_user(&self, _req: Request<Body<Vec<u8>>>) -> (u16, String) {
         (200, "Yo".to_string())
+    }
+
+    #[post("/multi")]
+    async fn multipart(&self, mut mul: Multipart) -> (u16, String) {
+        let mut multipart_image_count = 0;
+        while let Ok(Some(mut f)) = mul.next_field().await {
+            if f.content_type() == &mime::IMAGE_PNG {
+                f.save(format!("/tmp/{}.png", f.name())).await;
+                multipart_image_count += 1;
+            }
+        }
+
+        (200, format!("Multipart form data image saved on disk: {}", multipart_image_count))
     }
 }
 

--- a/saphir/src/lib.rs
+++ b/saphir/src/lib.rs
@@ -87,6 +87,9 @@ pub mod http_context;
 pub mod macros;
 ///
 pub mod middleware;
+/// The async Multipart Form-Data representation
+#[cfg(feature = "multipart")]
+pub mod multipart;
 /// The Http Request type
 pub mod request;
 /// Definition of type which can map to a response
@@ -141,6 +144,9 @@ pub mod prelude {
     pub use crate::macros::controller;
     ///
     pub use crate::middleware::MiddlewareChain;
+    ///
+    #[cfg(feature = "multipart")]
+    pub use crate::multipart::Multipart;
     ///
     pub use crate::request::Request;
     ///

--- a/saphir/src/multipart/mod.rs
+++ b/saphir/src/multipart/mod.rs
@@ -1,0 +1,275 @@
+use std::{fmt::Debug, str::FromStr, sync::Arc};
+
+use futures::TryStreamExt;
+use futures_util::stream::Stream;
+use mime::Mime;
+use nom::lib::std::fmt::Formatter;
+use parking_lot::Mutex;
+
+use crate::{body::Bytes, multipart::parser::ParseFieldError, request::Request};
+use std::path::Path;
+
+mod parser;
+
+#[derive(Debug)]
+pub enum MultipartError {
+    Parsing(ParseFieldError),
+    /// Error type returned when the current field was not consumed before tying
+    /// to get the next one
+    NotConsumed,
+    AlreadyConsumed,
+    MissingBoundary,
+    Finished,
+    Hyper(hyper::error::Error),
+    Io(std::io::Error),
+    #[cfg(feature = "json")]
+    Json(serde_json::error::Error),
+    #[cfg(feature = "form")]
+    Form(serde_urlencoded::de::Error),
+}
+
+impl From<ParseFieldError> for MultipartError {
+    fn from(e: ParseFieldError) -> Self {
+        if let ParseFieldError::Finished = e {
+            MultipartError::Finished
+        } else {
+            MultipartError::Parsing(e)
+        }
+    }
+}
+
+pub struct FieldStream {
+    inner: Option<ParseStream>,
+    paren: DataStream,
+}
+
+impl FieldStream {
+    pub(crate) fn stream(&mut self) -> &mut ParseStream {
+        self.inner.as_mut().expect("STREAM: Field stream should not exists with a uninitialized stream")
+    }
+}
+
+impl Drop for FieldStream {
+    fn drop(&mut self) {
+        let stream = self.inner.take().expect("RETURN: Field stream should not exists with a uninitialized stream");
+        self.paren.return_stream(stream)
+    }
+}
+
+pub(crate) struct ParseStream {
+    pub buf: Vec<u8>,
+    pub exhausted: bool,
+    pub stream: Box<dyn Stream<Item = Result<Bytes, MultipartError>> + Unpin + Send>,
+}
+
+#[derive(Clone)]
+struct DataStream {
+    inner: Arc<Mutex<Option<ParseStream>>>,
+}
+
+impl DataStream {
+    pub fn new<S>(s: S) -> Self
+    where
+        S: Stream<Item = Result<Bytes, MultipartError>> + Send + Unpin + 'static,
+    {
+        DataStream {
+            inner: Arc::new(Mutex::new(Some(ParseStream {
+                buf: vec![],
+                exhausted: false,
+                stream: Box::new(s),
+            }))),
+        }
+    }
+
+    pub fn take(&self) -> Option<FieldStream> {
+        if let Some(stream) = self.inner.lock().take() {
+            let paren = self.clone();
+            Some(FieldStream { inner: Some(stream), paren })
+        } else {
+            None
+        }
+    }
+
+    pub fn return_stream(&self, s: ParseStream) {
+        *self.inner.lock() = Some(s);
+    }
+}
+
+/// Represent a from-data field
+/// Only the data needed to construct the field will be read into memory
+pub struct Field {
+    name: String,
+    filename: Option<String>,
+    content_type: Mime,
+    content_transfer_encoding: Option<String>,
+    boundary: String,
+    stream: Option<FieldStream>,
+}
+
+impl Field {
+    /// Returns the `name` param of the `Content-Disposition` header
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the optional `filename` param of the `Content-Disposition`
+    /// header
+    pub fn filename(&self) -> Option<&str> {
+        self.filename.as_ref().map(|s| &**s)
+    }
+
+    /// Returns the optional `Content-Type` Mime and is defaulted to
+    /// `text/plain` as specified by the spec
+    pub fn content_type(&self) -> &Mime {
+        &self.content_type
+    }
+
+    /// Returns the next available chunk of data for this field
+    /// Calling this function repeatedly until the field is completely read will
+    /// result in Ok(None) being returned
+    pub async fn next_chunk(&mut self) -> Result<Option<Vec<u8>>, MultipartError> {
+        if self
+            .stream
+            .as_ref()
+            .and_then(|s| s.inner.as_ref())
+            .filter(|s| !s.exhausted || !s.buf.is_empty())
+            .is_none()
+        {
+            return Ok(None);
+        }
+
+        parser::parse_next_field_chunk(self.stream.as_mut().ok_or_else(|| MultipartError::AlreadyConsumed)?, self.boundary.as_str())
+            .await
+            .map(|b| if b.is_empty() { None } else { Some(b) })
+    }
+
+    /// Loads the entire field into memory and returns it as raw bytes
+    pub async fn as_raw(&mut self) -> Result<Vec<u8>, MultipartError> {
+        self.read_all().await
+    }
+
+    /// Loads the entire field into memory and returns it as plain text
+    pub async fn as_text(&mut self) -> Result<String, MultipartError> {
+        self.read_all().await.map(|b| String::from_utf8_lossy(b.as_slice()).to_string())
+    }
+
+    /// Loads the entire field into memory and parses it as JSON data *IF* the
+    /// content-type is `application/json`
+    #[cfg(feature = "json")]
+    pub async fn as_json<T>(&mut self) -> Result<Option<T>, MultipartError>
+    where
+        T: for<'a> serde::Deserialize<'a>,
+    {
+        if self.content_type == mime::APPLICATION_JSON {
+            let bytes = self.read_all().await?;
+            serde_json::from_slice::<T>(bytes.as_slice()).map_err(MultipartError::Json).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Loads the entire field into memory and parses it as Form urlencoded data
+    /// *IF* the content-type is `application/x-www-form-urlencoded`
+    #[cfg(feature = "form")]
+    pub async fn as_form<T>(&mut self) -> Result<Option<T>, MultipartError>
+    where
+        T: for<'a> serde::Deserialize<'a>,
+    {
+        if self.content_type == mime::APPLICATION_JSON {
+            let bytes = self.read_all().await?;
+            serde_urlencoded::from_bytes(bytes.as_slice()).map_err(MultipartError::Form).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Saves the field into a file on disk.
+    pub async fn save<P: AsRef<Path>>(&mut self, path: P) -> Result<usize, MultipartError> {
+        use tokio::io::AsyncWriteExt;
+        let mut file = tokio::fs::File::create(path).await.map_err(MultipartError::Io)?;
+        let mut bytes_writen = 0;
+        while let Some(bytes) = self.next_chunk().await? {
+            file.write_all(bytes.as_slice()).await.map_err(MultipartError::Io)?;
+            bytes_writen += bytes.len();
+        }
+
+        Ok(bytes_writen)
+    }
+
+    async fn read_all(&mut self) -> Result<Vec<u8>, MultipartError> {
+        parser::parse_field_data(self.stream.take().ok_or_else(|| MultipartError::AlreadyConsumed)?, self.boundary.as_str())
+            .await
+            .map(|mut b| {
+                if b[(b.len() - 2)..b.len()] == [0x0d, 0x0a] {
+                    b.truncate(b.len() - 2)
+                }
+
+                b
+            })
+    }
+}
+
+impl Debug for Field {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Field")
+            .field("name", &self.name)
+            .field("filename", &self.filename)
+            .field("content_type", &self.content_type)
+            .field("content_transfer_encoding", &self.content_transfer_encoding)
+            .field("boundary", &self.boundary)
+            .finish()
+    }
+}
+
+/// Struct used to parse a multipart body into fields
+pub struct Multipart {
+    boundary: String,
+    inner: DataStream,
+}
+
+impl Multipart {
+    /// Initialize a Multipart from a given request
+    /// This will consume the body
+    pub fn from_request(req: &mut Request) -> Result<Multipart, MultipartError> {
+        let boundary = req
+            .headers()
+            .get(http::header::CONTENT_TYPE)
+            .and_then(|c_t| c_t.to_str().ok())
+            .and_then(|c_t_str| Mime::from_str(c_t_str).ok())
+            .filter(|mime| mime.type_() == mime::MULTIPART && mime.subtype() == mime::FORM_DATA)
+            .as_ref()
+            .and_then(|mime| mime.get_param(mime::BOUNDARY))
+            .map(|name| name.to_string())
+            .ok_or_else(|| MultipartError::MissingBoundary)?;
+
+        let stream = req.body_mut().take().into_raw().map_err(MultipartError::Hyper);
+
+        Ok(Self::from_part(boundary, stream))
+    }
+
+    /// Initialize the Multipart from raw parts
+    pub fn from_part<S>(boundary: String, stream: S) -> Self
+    where
+        S: Stream<Item = Result<Bytes, MultipartError>> + Send + Unpin + 'static,
+    {
+        Multipart {
+            boundary,
+            inner: DataStream::new(stream),
+        }
+    }
+
+    /// Parse the next field inside the body
+    /// This will partially load the content, until the field "metadata" is
+    /// parsed
+    pub async fn next_field(&self) -> Result<Option<Field>, MultipartError> {
+        if let Some(s) = self.inner.take() {
+            match parser::parse_field(s, self.boundary.as_str()).await {
+                Ok(f) => Ok(Some(f)),
+                Err(MultipartError::Finished) => Ok(None),
+                Err(e) => Err(e),
+            }
+        } else {
+            Err(MultipartError::NotConsumed)
+        }
+    }
+}

--- a/saphir/src/multipart/parser.rs
+++ b/saphir/src/multipart/parser.rs
@@ -1,0 +1,377 @@
+use futures::StreamExt;
+use mime::Mime;
+use nom::{
+    alt, call, char, cond, delimited, do_parse, error::ErrorKind, map_res, named, opt, parse_to, preceded, tag, tag_no_case, take_until, IResult, Needed,
+};
+
+use crate::multipart::{Field, FieldStream, MultipartError, ParseStream};
+
+const BASE_BUFFER_SIZE: usize = 2048;
+
+#[derive(Debug)]
+pub enum ParseFieldError {
+    Finished,
+    NomError(ErrorKind),
+    MissingData(usize),
+    Io(std::io::Error),
+    Other(String),
+}
+
+enum FieldHeader<'a> {
+    Disposition((&'a str, Option<&'a str>)),
+    Type(Mime),
+    TransferEncoding(&'a str),
+}
+
+pub struct FieldHeaders<'a> {
+    content_disposition_name: &'a str,
+    content_disposition_filename: Option<&'a str>,
+    content_type: Option<Mime>,
+    content_transfer_encoding: Option<&'a str>,
+}
+
+impl From<std::io::Error> for ParseFieldError {
+    fn from(e: std::io::Error) -> Self {
+        ParseFieldError::Io(e)
+    }
+}
+
+named!(mime_parser<&str, Mime>, parse_to!(Mime));
+named!(until_line_end, take_until!("\r\n"));
+named!(line_ending, alt!(tag!("\r\n") | tag!("\n")));
+
+pub fn tag_boundary<'a>(tag: &'a str) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], bool> {
+    move |i: &'a [u8]| {
+        do_parse!(
+            i,
+            tag!("--") >> tag!(tag) >> ending: map_res!(call!(until_line_end), std::str::from_utf8) >> line_ending >> (ending == "--")
+        )
+    }
+}
+
+fn parse_content_type(input: &[u8]) -> IResult<&[u8], FieldHeader> {
+    do_parse!(
+        input,
+        mime: map_res!(map_res!(until_line_end, std::str::from_utf8), mime_parser) >> (FieldHeader::Type(mime.1))
+    )
+}
+
+fn parse_content_disposition(input: &[u8]) -> IResult<&[u8], FieldHeader> {
+    do_parse!(
+        input,
+        tag_no_case!("form-data; ")
+            >> tag!("name=")
+            >> name: map_res!(delimited!(char!('"'), take_until!("\""), char!('"')), std::str::from_utf8)
+            >> file: opt!(tag!("; filename="))
+            >> filename:
+                cond!(
+                    file.is_some(),
+                    map_res!(delimited!(char!('"'), take_until!("\""), char!('"')), std::str::from_utf8)
+                )
+            >> (FieldHeader::Disposition((name, filename)))
+    )
+}
+
+fn parse_transfer_encoding(input: &[u8]) -> IResult<&[u8], FieldHeader> {
+    do_parse!(
+        input,
+        value: map_res!(call!(until_line_end), std::str::from_utf8) >> (FieldHeader::TransferEncoding(value))
+    )
+}
+
+fn header(input: &[u8]) -> IResult<&[u8], Option<FieldHeader>> {
+    if input.is_empty() {
+        return Ok((input, None));
+    }
+
+    let (_, out) = until_line_end(input)?;
+
+    if out.len() <= 1 {
+        return Ok((input, None));
+    }
+
+    do_parse!(
+        input,
+        tag_no_case!("content-")
+            >> field:
+                alt!(
+                    preceded!(tag_no_case!("type: "), call!(parse_content_type))
+                        | preceded!(tag_no_case!("disposition: "), call!(parse_content_disposition))
+                        | preceded!(tag_no_case!("transfer-encoding: "), call!(parse_transfer_encoding))
+                )
+            >> line_ending
+            >> (Some(field))
+    )
+}
+
+fn headers(input: &[u8]) -> IResult<&[u8], FieldHeaders> {
+    let mut content_disposition = None;
+    let mut content_type = None;
+    let mut content_transfer_encoding = None;
+    let mut input = input;
+    loop {
+        match header(input) {
+            Ok((i, header)) => {
+                input = i;
+                match header {
+                    Some(FieldHeader::Disposition(name)) => content_disposition = Some(name),
+                    Some(FieldHeader::Type(mime)) => content_type = Some(mime),
+                    Some(FieldHeader::TransferEncoding(enc)) => content_transfer_encoding = Some(enc),
+                    None => {
+                        input = line_ending(input)?.0;
+                        break;
+                    }
+                }
+            }
+            Err(nom::Err::Error((_, ErrorKind::Tag))) => {
+                let (i, _) = do_parse!(input, call!(until_line_end) >> line_ending >> ())?;
+                input = i;
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    let (content_disposition_name, content_disposition_filename) =
+        content_disposition.ok_or_else(|| nom::Err::Error((input, nom::error::ErrorKind::MapOpt)))?;
+
+    Ok((
+        input,
+        FieldHeaders {
+            content_disposition_name,
+            content_type,
+            content_transfer_encoding,
+            content_disposition_filename,
+        },
+    ))
+}
+
+fn field<'a>(input: &'a [u8], bound: &'a str) -> Result<(&'a [u8], FieldHeaders<'a>), ParseFieldError> {
+    let res = do_parse!(input, finished: call!(tag_boundary(bound)) >> f: cond!(!finished, call!(headers)) >> (f));
+
+    match res {
+        Ok((i, Some(f))) => Ok((i, f)),
+        Ok((_i, None)) => Err(ParseFieldError::Finished),
+        Err(nom::Err::Incomplete(Needed::Size(size))) => Err(ParseFieldError::MissingData(size)),
+        Err(nom::Err::Incomplete(Needed::Unknown)) => Err(ParseFieldError::MissingData(1024)),
+        Err(nom::Err::Error((_, k))) | Err(nom::Err::Failure((_, k))) => Err(ParseFieldError::NomError(k)),
+    }
+}
+
+async fn buf_data(parse_ctx: &mut ParseStream, additional_size: usize) -> Result<bool, MultipartError> {
+    if parse_ctx.exhausted {
+        return if parse_ctx.buf.is_empty() { Err(MultipartError::Finished) } else { Ok(false) };
+    }
+
+    loop {
+        match parse_ctx.stream.next().await.transpose()? {
+            None => {
+                if !parse_ctx.buf.is_empty() {
+                    parse_ctx.exhausted = true;
+                    break Ok(false);
+                } else {
+                    break Err(MultipartError::Finished);
+                }
+            }
+            Some(b) => {
+                parse_ctx.buf.extend_from_slice(b.as_ref());
+            }
+        }
+
+        if parse_ctx.buf.len() >= BASE_BUFFER_SIZE + additional_size {
+            break Ok(true);
+        }
+    }
+}
+
+async fn drain_current(stream: &mut FieldStream, boundary: &str) -> Result<(), MultipartError> {
+    while !parse_next_field_chunk(stream, boundary).await?.is_empty() {}
+
+    Ok(())
+}
+
+pub async fn parse_field(mut stream: FieldStream, boundary: &str) -> Result<Field, MultipartError> {
+    drain_current(&mut stream, boundary).await?;
+
+    let parse_ctx = stream.stream();
+    let mut additional_size = 0usize;
+
+    loop {
+        if buf_data(parse_ctx, additional_size).await? {
+            additional_size = 0;
+        }
+
+        let buf = &mut parse_ctx.buf;
+
+        match field(buf.as_slice(), boundary) {
+            Ok((i, f)) => {
+                let name = f.content_disposition_name.to_string();
+                let filename = f.content_disposition_filename.map(|s| s.to_string());
+                let content_type = f.content_type.unwrap_or_else(|| mime::TEXT_PLAIN.clone());
+                let content_transfer_encoding = f.content_transfer_encoding.map(|s| s.to_string());
+                *buf = i.to_vec();
+                return Ok(Field {
+                    name,
+                    filename,
+                    content_type,
+                    content_transfer_encoding,
+                    boundary: boundary.to_string(),
+                    stream: Some(stream),
+                });
+            }
+            Err(ParseFieldError::MissingData(size)) if !parse_ctx.exhausted => {
+                additional_size += size;
+            }
+            Err(e) => {
+                return Err(e.into());
+            }
+        }
+    }
+}
+
+pub async fn parse_next_field_chunk(stream: &mut FieldStream, boundary: &str) -> Result<Vec<u8>, MultipartError> {
+    let data;
+    let parse_ctx = stream.stream();
+    let mut boundary = boundary.to_string();
+
+    boundary.insert_str(0, "--");
+
+    let boundary_len = boundary.len();
+
+    buf_data(parse_ctx, 0).await?;
+
+    let buf = &mut parse_ctx.buf;
+    let res: IResult<&[u8], &[u8]> = take_until!(buf.as_slice(), boundary.as_str());
+    match res {
+        Ok((input, taken)) => {
+            data = taken.to_vec();
+            *buf = input.to_vec();
+        }
+        Err(_) => {
+            if parse_ctx.exhausted {
+                data = buf.drain(0..buf.len()).collect();
+            } else {
+                data = buf[0..(buf.len() - boundary_len)].to_vec();
+                *buf = buf[(buf.len() - boundary_len - 1)..buf.len()].to_vec();
+            }
+        }
+    }
+
+    Ok(data)
+}
+
+pub async fn parse_field_data(mut stream: FieldStream, boundary: &str) -> Result<Vec<u8>, MultipartError> {
+    let parse_ctx = stream.stream();
+    let mut additional_size = 0usize;
+
+    let mut data = Vec::new();
+
+    let mut boundary = boundary.to_string();
+
+    boundary.insert_str(0, "--");
+
+    let boundary_len = boundary.len();
+
+    loop {
+        if buf_data(parse_ctx, additional_size).await? {
+            additional_size = 0;
+        }
+
+        let buf = &mut parse_ctx.buf;
+        let res: IResult<&[u8], &[u8]> = take_until!(buf.as_slice(), boundary.as_str());
+        match res {
+            Ok((input, taken)) => {
+                data.extend_from_slice(taken);
+                *buf = input.to_vec();
+                return Ok(data);
+            }
+            Err(_) => {
+                if parse_ctx.exhausted {
+                    data.extend_from_slice(buf.as_slice());
+                    return Ok(data);
+                } else {
+                    data.extend_from_slice(&buf[0..(buf.len() - boundary_len)]);
+                    *buf = buf[(buf.len() - boundary_len - 1)..buf.len()].to_vec();
+                    additional_size += 1024
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nom::Needed;
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn test_tag_boundary() {
+        let boundary = "----AaB03x";
+        let boundary_no_ending = &b"------AaB03x\r\nContent-Type: text/plain\r\n"[..];
+        let boundary_ending = &b"------AaB03x--\r\n"[..];
+        let boundary_partial = &b"------AaB"[..];
+        let empty = &b""[..];
+
+        assert_eq!(tag_boundary(boundary)(boundary_partial), Err(nom::Err::Incomplete(Needed::Size(10))));
+        assert_eq!(tag_boundary(boundary)(boundary_no_ending), Ok((&b"Content-Type: text/plain\r\n"[..], false)));
+        assert_eq!(tag_boundary(boundary)(boundary_ending), Ok((empty, true)));
+    }
+
+    #[test]
+    fn test_headers_correct() {
+        let headers_dada = &b"\
+        content-disposition: form-data; name=\"field1\"; filename=\"file.txt\"\r\n\
+        content-type: text/plain;charset=UTF-8\r\n\
+        content-transfer-encoding: quoted-printable\r\n\
+        \r\n\
+        this is plain text data"[..];
+
+        let (input, field_headers) = headers(headers_dada).unwrap();
+
+        assert_eq!(field_headers.content_transfer_encoding, Some("quoted-printable"));
+        assert_eq!(field_headers.content_type, Some(Mime::from_str("text/plain;charset=UTF-8").unwrap()));
+        assert_eq!(field_headers.content_disposition_name, "field1");
+        assert_eq!(field_headers.content_disposition_filename.as_ref().map(|s| &**s), Some("file.txt"));
+        assert_eq!(input, &b"this is plain text data"[..]);
+    }
+
+    #[test]
+    fn test_headers_correct_with_ignored() {
+        let headers_dada = &b"\
+        accept-encoding: UTF-8\r\n\
+        content-disposition: form-data; name=\"field1\"\r\n\
+        content-type: text/plain;charset=UTF-8\r\n\
+        authorization: bearer asdjasdoijeferor39tj4efsuigfe\r\n\
+        content-transfer-encoding: quoted-printable\r\n\
+        \r\n\
+        this is plain text data"[..];
+
+        let (_input, field_headers) = headers(headers_dada).unwrap();
+
+        assert_eq!(field_headers.content_transfer_encoding, Some("quoted-printable"));
+        assert_eq!(field_headers.content_type, Some(Mime::from_str("text/plain;charset=UTF-8").unwrap()));
+        assert_eq!(field_headers.content_disposition_name, "field1");
+    }
+
+    #[test]
+    fn test_partial_field() {
+        let data = &b"\
+        --AaB03x\r\n\
+        content-disposition: form-data; name=\"empty-field\"\r\n\
+        content-type: text/plain\r\n\
+        \r\n\
+        --AaB03x--\r\n"[..];
+
+        let (out, field_h) = field(data, "AaB03x").unwrap();
+        assert_eq!(field_h.content_disposition_name, "empty-field");
+        assert_eq!(field_h.content_type, Some(Mime::from_str("text/plain").unwrap()));
+
+        if let Err(ParseFieldError::Finished) = field(out, "AaB03x") {
+            assert!(true);
+        } else {
+            assert!(false);
+        }
+    }
+}

--- a/saphir/src/server.rs
+++ b/saphir/src/server.rs
@@ -626,7 +626,7 @@ pub async fn inject_raw(req: RawRequest<RawBody>) -> Result<RawResponse<RawBody>
     // We checked that memory has been initialized above
     let stack = unsafe { STACK.as_ptr().as_ref().expect("Memory has been initialized above.") };
 
-    let saphir_req = Request::new(req.map(|body| Body::from_raw(body)), None);
+    let saphir_req = Request::new(req.map(Body::from_raw), None);
     let saphir_res = stack.invoke(saphir_req).await?;
     Ok(saphir_res.into_raw().map(|r| r.map(|b| b.into_raw()))?)
 }

--- a/saphir_macro/Cargo.toml
+++ b/saphir_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saphir_macro"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Richer Archambault <richer.arc@gmail.com>"]
 edition = "2018"
 description = "Macro generation for http server framework"


### PR DESCRIPTION
This includes this initial implementation of Multipart Data support in saphir.

The idea is to consider a Multipart struct as a stream of fields, each one being asynchronously read chunk by chunk when needed.

A simplke way to use it would be :
```Rust
while let Ok(Some(mut field)) = multipart.next_field().await {
    // Do something with the current field
}
```