### PR TITLE
Version 2.2

### DIFF
--- a/saphir/Cargo.toml
+++ b/saphir/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 
 [features]
 default = ["macro"]
-full = ["macro", "json", "form", "https", "multipart"]
+full = ["macro", "json", "form", "https", "multipart", "operation"]
 https = ["base64", "rustls", "tokio-rustls"]
 json = ["serde", "serde_json"]
 form = ["serde", "serde_urlencoded"]

--- a/saphir/Cargo.toml
+++ b/saphir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saphir"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2018"
 authors = ["Richer Archambault <richer.arc@gmail.com>"]
 description = "Fully async-await http server framework"
@@ -19,6 +19,7 @@ json = ["serde", "serde_json"]
 form = ["serde", "serde_urlencoded"]
 macro = ["saphir_macro"]
 multipart = ["mime", "nom"]
+operation = ["hex", "rand", "serde"]
 
 [dependencies]
 log = "0.4"
@@ -41,6 +42,8 @@ serde_urlencoded = { version = "0.6", optional = true }
 saphir_macro = { path = "../saphir_macro", version = "1.1.0", optional = true}
 mime = { version = "0.3", optional = true }
 nom = { version = "5", optional = true }
+hex = { version = "0.4", optional = true }
+rand = { version = "0.7.3", optional = true }
 
 [dev-dependencies]
 tokio-timer = "0.2.13"

--- a/saphir/src/http_context.rs
+++ b/saphir/src/http_context.rs
@@ -1,11 +1,134 @@
-use crate::{request::Request, router::Router};
-use std::sync::atomic::AtomicU64;
+use crate::{request::Request, response::Response, router::Router};
 
-const SERVER_ID_OFFSET: usize = 0;
-const TIMESTAMP_OFFSET: usize = 4;
-const OPERATION_ID_OFFSET: usize = 10;
-const OPERATION_ID_MAX: usize = 16;
-static OP_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+/// State of the Http context. It represent whether the context is used
+/// `Before(..)` or `After(..)` calling the handler responsible of generating a
+/// responder. Empty will be the state of a context when the request is being
+/// processed by the handler, or when its original state has been moved by using
+/// take & take unchecked methods
+pub enum State {
+    Before(Request),
+    After(Response),
+    Empty,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::Empty
+    }
+}
+
+impl State {
+    /// Take the current context leaving `State::Empty` behind
+    pub fn take(&mut self) -> Self {
+        std::mem::take(self)
+    }
+
+    /// Take the current request leaving `State::Empty` behind
+    /// Returns `Some(Request)` if the state was `Before` or `None` if it was
+    /// something else
+    pub fn take_request(&mut self) -> Option<Request> {
+        match std::mem::take(self) {
+            State::Before(r) => Some(r),
+            _ => None,
+        }
+    }
+
+    /// Take the current request leaving `State::Empty` behind
+    /// Panics if the state is not `Before`
+    pub fn take_request_unchecked(&mut self) -> Request {
+        match std::mem::take(self) {
+            State::Before(r) => r,
+            _ => panic!("State::take_request_unchecked should be called only before the handler & when it is ensured that the request wasn't moved"),
+        }
+    }
+
+    /// Take the current response leaving `State::Empty` behind
+    /// Returns `Some(Response)` if the state was `After` or `None` if it was
+    /// something else
+    pub fn take_response(&mut self) -> Option<Response> {
+        match std::mem::take(self) {
+            State::After(r) => Some(r),
+            _ => None,
+        }
+    }
+
+    /// Take the current response leaving `State::Empty` behind
+    /// Panics if the state is not `After`
+    pub fn take_response_unchecked(&mut self) -> Response {
+        match std::mem::take(self) {
+            State::After(r) => r,
+            _ => panic!("State::take_response_unchecked should be called only after the handler & when it is ensured that the response wasn't moved"),
+        }
+    }
+
+    /// Returns `Some` of the current request if state if `Before`
+    pub fn request(&self) -> Option<&Request> {
+        match self {
+            State::Before(r) => Some(r),
+            _ => None,
+        }
+    }
+
+    /// Returns `Some` of the current request as a mutable ref if state if
+    /// `Before`
+    pub fn request_mut(&mut self) -> Option<&Request> {
+        match self {
+            State::Before(r) => Some(r),
+            _ => None,
+        }
+    }
+
+    /// Returns the current request, panics if state is not `Before`
+    pub fn request_unchecked(&self) -> &Request {
+        match self {
+            State::Before(r) => r,
+            _ => panic!("State::request_unchecked should be called only before the handler & when it is ensured that the request wasn't moved"),
+        }
+    }
+
+    /// Returns the current request as a mutable ref, panics if state is not
+    /// `Before`
+    pub fn request_unchecked_mut(&mut self) -> &mut Request {
+        match self {
+            State::Before(r) => r,
+            _ => panic!("State::request_unchecked_mut should be called only before the handler & when it is ensured that the request wasn't moved"),
+        }
+    }
+
+    /// Returns `Some` of the current response if state if `After`
+    pub fn response(&self) -> Option<&Response> {
+        match self {
+            State::After(r) => Some(r),
+            _ => None,
+        }
+    }
+
+    /// Returns `Some` of the current response as a mutable ref if state if
+    /// `After`
+    pub fn response_mut(&mut self) -> Option<&mut Response> {
+        match self {
+            State::After(r) => Some(r),
+            _ => None,
+        }
+    }
+
+    /// Returns the current response, panics if state is not `After`
+    pub fn response_unchecked(&self) -> &Response {
+        match self {
+            State::After(r) => r,
+            _ => panic!("State::response_unchecked should be called only before the handler & when it is ensured that the request wasn't moved"),
+        }
+    }
+
+    /// Returns the current response as a mutable ref, panics if state is not
+    /// `After`
+    pub fn response_unchecked_mut(&mut self) -> &mut Response {
+        match self {
+            State::After(r) => r,
+            _ => panic!("State::response_unchecked_mut should be called only before the handler & when it is ensured that the request wasn't moved"),
+        }
+    }
+}
 
 /// Context representing the relationship between a request and a response
 /// This structure only appears inside Middleware since the act before and after
@@ -13,73 +136,277 @@ static OP_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 ///
 /// There is no guaranty the the request nor the response will be set at any
 /// given time, since they could be moved out by a badly implemented middleware
-pub struct HttpContext<B> {
-    /// The incoming request before it is handled by the router
-    pub request: Request<B>,
-    pub(crate) router: Router,
+pub struct HttpContext {
+    /// The incoming request `Before` it is handled by the router
+    /// OR
+    /// The outgoing response `After` the request was handled by the router
+    pub state: State,
+    #[cfg(feature = "operation")]
+    /// Unique Identifier of the current request->response chain
+    pub operation_id: crate::http_context::operation::OperationId,
+    pub(crate) router: Option<Router>,
 }
 
-impl<B> HttpContext<B> {
-    pub(crate) fn new(request: Request<B>, router: Router) -> Self {
-        HttpContext { request, router }
+impl HttpContext {
+    #[cfg(not(feature = "operation"))]
+    pub(crate) fn new(request: Request, router: Router) -> Self {
+        let state = State::Before(request);
+        let router = Some(router);
+        HttpContext { state, router }
+    }
+
+    #[cfg(feature = "operation")]
+    pub(crate) fn new(server_id: u32, mut request: Request, router: Router) -> Self {
+        let operation_id = crate::http_context::operation::OperationId::new(server_id);
+        *request.operation_id_mut() = operation_id.clone();
+        let state = State::Before(request);
+        let router = Some(router);
+        HttpContext { state, router, operation_id }
     }
 }
 
-pub struct OperationId {
-    bytes: [u8; 16],
-}
+#[cfg(feature = "operation")]
+pub mod operation {
+    use hex::encode_to_slice;
+    use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+    use std::{
+        fmt::{Display, Formatter},
+        str::FromStr,
+        sync::atomic::AtomicU64,
+    };
 
-impl OperationId {
-    pub fn new(server_id: u32) -> OperationId {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let t_s = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("UNIX EPOCH should be in the past")
-            .as_secs();
+    const SERVER_ID_OFFSET: usize = 0;
+    const TIMESTAMP_OFFSET: usize = 4;
+    const OPERATION_ID_OFFSET: usize = 10;
+    const OPERATION_ID_MAX: usize = 16;
+    const OPERATION_ID_STR_LEN: usize = OPERATION_ID_MAX * 2 + 2;
+    static OP_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 
-        let count = OP_ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-        let mut bytes = [0u8; 16];
-        buf[SERVER_ID_OFFSET..TIMESTAMP_OFFSET].clone_from_slice(&server_id.to_le_bytes());
-        buf[TIMESTAMP_OFFSET..OPERATION_ID_OFFSET].clone_from_slice(&t_s.to_le_bytes()[0..6]);
-        buf[OPERATION_ID_OFFSET..OPERATION_ID_MAX].clone_from_slice(&count.to_le_bytes()[0..6]);
-
-        OperationId { bytes }
+    /// Represent a single operation from a incoming request until a response is
+    /// produced
+    #[derive(Clone, PartialOrd, PartialEq)]
+    pub struct OperationId {
+        bytes: [u8; 16],
     }
 
-    pub fn to_string(&self) -> String {
-        let mut s = String::with_capacity(34);
-    }
+    impl OperationId {
+        pub fn new(server_id: u32) -> OperationId {
+            use std::time::{SystemTime, UNIX_EPOCH};
+            let t_s = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("UNIX EPOCH should be in the past")
+                .as_secs();
 
-    fn encode<'a>(&self) -> &'a mut str {
-        let len = if hyphens { 36 } else { 32 };
+            let count = OP_ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        {
-            let buffer = &mut full_buffer[start..start + len];
-            let bytes = uuid.as_bytes();
+            Self::with_part(server_id, t_s, count)
+        }
 
-            let hex = if upper { &UPPER } else { &LOWER };
+        pub fn with_part(server_id: u32, timestamp: u64, count: u64) -> OperationId {
+            let mut bytes = [0u8; 16];
+            bytes[SERVER_ID_OFFSET..TIMESTAMP_OFFSET].copy_from_slice(&server_id.to_be_bytes());
+            bytes[TIMESTAMP_OFFSET..OPERATION_ID_OFFSET].copy_from_slice(&timestamp.to_be_bytes()[2..8]);
+            bytes[OPERATION_ID_OFFSET..OPERATION_ID_MAX].copy_from_slice(&count.to_be_bytes()[2..8]);
 
-            for group in 0..5 {
-                // If we're writing hyphens, we need to shift the output
-                // location along by how many of them have been written
-                // before this point. That's exactly the (0-indexed) group
-                // number.
-                let hyphens_before = if hyphens { group } else { 0 };
-                for idx in BYTE_POSITIONS[group]..BYTE_POSITIONS[group + 1] {
-                    let b = bytes[idx];
-                    let out_idx = hyphens_before + 2 * idx;
+            OperationId { bytes }
+        }
 
-                    buffer[out_idx] = hex[(b >> 4) as usize];
-                    buffer[out_idx + 1] = hex[(b & 0b1111) as usize];
+        pub(crate) fn with_bytes(bytes: [u8; 16]) -> OperationId {
+            OperationId { bytes }
+        }
+
+        pub fn to_string(&self) -> String {
+            let mut vec = vec![0u8; OPERATION_ID_STR_LEN];
+
+            vec.get_mut(..)
+                .map(|bytes| {
+                    bytes.get_mut(SERVER_ID_OFFSET..TIMESTAMP_OFFSET * 2).map(|dst| self.encode_part(dst, 0));
+                    bytes.get_mut(TIMESTAMP_OFFSET * 2).map(|byte| *byte = '-' as u8);
+                    bytes
+                        .get_mut(TIMESTAMP_OFFSET * 2 + 1..OPERATION_ID_OFFSET * 2 + 1)
+                        .map(|dst| self.encode_part(dst, 1));
+                    bytes.get_mut(OPERATION_ID_OFFSET * 2 + 1).map(|byte| *byte = '-' as u8);
+                    bytes
+                        .get_mut(OPERATION_ID_OFFSET * 2 + 2..OPERATION_ID_MAX * 2 + 2)
+                        .map(|dst| self.encode_part(dst, 2));
+                })
+                .and_then(|_| String::from_utf8(vec).ok())
+                .expect("Encode should never produce non-ascii chars")
+        }
+
+        pub fn to_u128(&self) -> u128 {
+            let mut bytes = [0u8; 16];
+            bytes.copy_from_slice(&self.bytes);
+            u128::from_le_bytes(bytes)
+        }
+
+        pub fn server_id(&self) -> u32 {
+            let mut s_id_bytes = [0u8; 4];
+            self.bytes.get(SERVER_ID_OFFSET..TIMESTAMP_OFFSET).map(|b| s_id_bytes.copy_from_slice(b));
+            u32::from_be_bytes(s_id_bytes)
+        }
+
+        pub fn timestamp(&self) -> u64 {
+            let mut bytes = [0u8; 8];
+            bytes
+                .get_mut(2..2 + (OPERATION_ID_OFFSET - TIMESTAMP_OFFSET))
+                .and_then(|t_b| self.bytes.get(TIMESTAMP_OFFSET..OPERATION_ID_OFFSET).map(|b| t_b.copy_from_slice(b)));
+            u64::from_be_bytes(bytes)
+        }
+
+        pub fn count(&self) -> u64 {
+            let mut bytes = [0u8; 8];
+            bytes
+                .get_mut(2..2 + (OPERATION_ID_MAX - OPERATION_ID_OFFSET))
+                .and_then(|t_b| self.bytes.get(OPERATION_ID_OFFSET..OPERATION_ID_MAX).map(|b| t_b.copy_from_slice(b)));
+            u64::from_be_bytes(bytes)
+        }
+
+        fn encode_part(&self, dst: &mut [u8], part: usize) {
+            match part {
+                0 => {
+                    let slice = &self.bytes[SERVER_ID_OFFSET..TIMESTAMP_OFFSET];
+                    if dst.len() >= slice.len() * 2 {
+                        encode_to_slice(slice, dst).expect("This will always work 0");
+                    }
                 }
-
-                if group != 4 && hyphens {
-                    buffer[HYPHEN_POSITIONS[group]] = b'-';
+                1 => {
+                    let slice = &self.bytes[TIMESTAMP_OFFSET..OPERATION_ID_OFFSET];
+                    if dst.len() >= slice.len() * 2 {
+                        encode_to_slice(slice, dst).expect("This will always work 1");
+                    }
+                }
+                _ => {
+                    let slice = &self.bytes[OPERATION_ID_OFFSET..OPERATION_ID_MAX];
+                    if dst.len() >= slice.len() * 2 {
+                        encode_to_slice(slice, dst).expect("This will always work 2");
+                    }
                 }
             }
         }
+    }
 
-        str::from_utf8_mut(&mut full_buffer[..start + len]).expect("found non-ASCII output characters while encoding a UUID")
+    impl Display for OperationId {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            f.write_str(self.to_string().as_str())
+        }
+    }
+
+    #[derive(Debug)]
+    pub enum ParseError {
+        MissingSegment,
+        InvalidHex(hex::FromHexError),
+    }
+
+    impl Display for ParseError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            match self {
+                ParseError::MissingSegment => f.write_str("Missing Segment"),
+                ParseError::InvalidHex(e) => e.fmt(f),
+            }
+        }
+    }
+
+    impl FromStr for OperationId {
+        type Err = ParseError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            let mut split = s.split('-');
+            let mut bytes = [0u8; 16];
+
+            hex::decode_to_slice(
+                split.next().ok_or_else(|| ParseError::MissingSegment)?,
+                &mut bytes[SERVER_ID_OFFSET..TIMESTAMP_OFFSET],
+            )
+            .map_err(|e| ParseError::InvalidHex(e))?;
+            hex::decode_to_slice(
+                split.next().ok_or_else(|| ParseError::MissingSegment)?,
+                &mut bytes[TIMESTAMP_OFFSET..OPERATION_ID_OFFSET],
+            )
+            .map_err(|e| ParseError::InvalidHex(e))?;
+            hex::decode_to_slice(
+                split.next().ok_or_else(|| ParseError::MissingSegment)?,
+                &mut bytes[OPERATION_ID_OFFSET..OPERATION_ID_MAX],
+            )
+            .map_err(|e| ParseError::InvalidHex(e))?;
+
+            Ok(OperationId { bytes })
+        }
+    }
+
+    struct OperationIdVisitor;
+
+    impl<'de> Visitor<'de> for OperationIdVisitor {
+        type Value = OperationId;
+
+        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            formatter.write_str("Invalid operation id")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            v.parse::<OperationId>().map_err(|e| serde::de::Error::custom(e))
+        }
+
+        fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            v.parse::<OperationId>().map_err(|e| serde::de::Error::custom(e))
+        }
+    }
+
+    impl<'de> Deserialize<'de> for OperationId {
+        fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserializer.deserialize_str(OperationIdVisitor)
+        }
+    }
+
+    impl Serialize for OperationId {
+        fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_str(self.to_string().as_str())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use crate::http_context::operation::OperationId;
+        use std::str::FromStr;
+
+        #[test]
+        pub fn operation_with_part() {
+            let op_id = OperationId::with_part(1, 1530000000, 12);
+
+            assert_eq!(op_id.server_id(), 1);
+            assert_eq!(op_id.timestamp(), 1530000000);
+            assert_eq!(op_id.count(), 12);
+            assert_eq!(op_id.to_u128(), 15950735949419599405423994206418894848);
+
+            let str_id = op_id.to_string();
+            let mut split = str_id.split('-');
+
+            assert_eq!(split.next(), Some("00000001"));
+            assert_eq!(split.next(), Some("00005b31f280"));
+            assert_eq!(split.next(), Some("00000000000c"));
+            assert_eq!(split.next(), None);
+        }
+
+        #[test]
+        pub fn operation_from_str() {
+            let op_id = OperationId::from_str("00000001-00005b31f280-00000000000c").unwrap();
+
+            assert_eq!(op_id.server_id(), 1);
+            assert_eq!(op_id.timestamp(), 1530000000);
+            assert_eq!(op_id.count(), 12);
+            assert_eq!(op_id.to_u128(), 15950735949419599405423994206418894848);
+        }
     }
 }

--- a/saphir/src/http_context.rs
+++ b/saphir/src/http_context.rs
@@ -1,4 +1,11 @@
 use crate::{request::Request, router::Router};
+use std::sync::atomic::AtomicU64;
+
+const SERVER_ID_OFFSET: usize = 0;
+const TIMESTAMP_OFFSET: usize = 4;
+const OPERATION_ID_OFFSET: usize = 10;
+const OPERATION_ID_MAX: usize = 16;
+static OP_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Context representing the relationship between a request and a response
 /// This structure only appears inside Middleware since the act before and after
@@ -15,5 +22,64 @@ pub struct HttpContext<B> {
 impl<B> HttpContext<B> {
     pub(crate) fn new(request: Request<B>, router: Router) -> Self {
         HttpContext { request, router }
+    }
+}
+
+pub struct OperationId {
+    bytes: [u8; 16],
+}
+
+impl OperationId {
+    pub fn new(server_id: u32) -> OperationId {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let t_s = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("UNIX EPOCH should be in the past")
+            .as_secs();
+
+        let count = OP_ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let mut bytes = [0u8; 16];
+        buf[SERVER_ID_OFFSET..TIMESTAMP_OFFSET].clone_from_slice(&server_id.to_le_bytes());
+        buf[TIMESTAMP_OFFSET..OPERATION_ID_OFFSET].clone_from_slice(&t_s.to_le_bytes()[0..6]);
+        buf[OPERATION_ID_OFFSET..OPERATION_ID_MAX].clone_from_slice(&count.to_le_bytes()[0..6]);
+
+        OperationId { bytes }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(34);
+    }
+
+    fn encode<'a>(&self) -> &'a mut str {
+        let len = if hyphens { 36 } else { 32 };
+
+        {
+            let buffer = &mut full_buffer[start..start + len];
+            let bytes = uuid.as_bytes();
+
+            let hex = if upper { &UPPER } else { &LOWER };
+
+            for group in 0..5 {
+                // If we're writing hyphens, we need to shift the output
+                // location along by how many of them have been written
+                // before this point. That's exactly the (0-indexed) group
+                // number.
+                let hyphens_before = if hyphens { group } else { 0 };
+                for idx in BYTE_POSITIONS[group]..BYTE_POSITIONS[group + 1] {
+                    let b = bytes[idx];
+                    let out_idx = hyphens_before + 2 * idx;
+
+                    buffer[out_idx] = hex[(b >> 4) as usize];
+                    buffer[out_idx + 1] = hex[(b & 0b1111) as usize];
+                }
+
+                if group != 4 && hyphens {
+                    buffer[HYPHEN_POSITIONS[group]] = b'-';
+                }
+            }
+        }
+
+        str::from_utf8_mut(&mut full_buffer[..start + len]).expect("found non-ASCII output characters while encoding a UUID")
     }
 }

--- a/saphir/src/http_context.rs
+++ b/saphir/src/http_context.rs
@@ -34,6 +34,8 @@ impl State {
     }
 
     /// Take the current request leaving `State::Empty` behind
+    ///
+    /// # Panics
     /// Panics if the state is not `Before`
     pub fn take_request_unchecked(&mut self) -> Request {
         match std::mem::take(self) {
@@ -53,6 +55,8 @@ impl State {
     }
 
     /// Take the current response leaving `State::Empty` behind
+    ///
+    /// # Panics
     /// Panics if the state is not `After`
     pub fn take_response_unchecked(&mut self) -> Response {
         match std::mem::take(self) {
@@ -78,7 +82,10 @@ impl State {
         }
     }
 
-    /// Returns the current request, panics if state is not `Before`
+    /// Returns the current request
+    ///
+    /// # Panics
+    /// Panics if state is not `Before`
     pub fn request_unchecked(&self) -> &Request {
         match self {
             State::Before(r) => r,
@@ -86,8 +93,10 @@ impl State {
         }
     }
 
-    /// Returns the current request as a mutable ref, panics if state is not
-    /// `Before`
+    /// Returns the current request as a mutable ref
+    ///
+    /// # Panics
+    /// panics if state is not `Before`
     pub fn request_unchecked_mut(&mut self) -> &mut Request {
         match self {
             State::Before(r) => r,
@@ -112,7 +121,10 @@ impl State {
         }
     }
 
-    /// Returns the current response, panics if state is not `After`
+    /// Returns the current response
+    ///
+    /// # Panics
+    /// Panics if state is not `After`
     pub fn response_unchecked(&self) -> &Response {
         match self {
             State::After(r) => r,
@@ -120,8 +132,10 @@ impl State {
         }
     }
 
-    /// Returns the current response as a mutable ref, panics if state is not
-    /// `After`
+    /// Returns the current response as a mutable ref
+    ///
+    /// # Panics
+    /// Panics if state is not `After`
     pub fn response_unchecked_mut(&mut self) -> &mut Response {
         match self {
             State::After(r) => r,

--- a/saphir/src/lib.rs
+++ b/saphir/src/lib.rs
@@ -137,6 +137,8 @@ pub mod prelude {
     pub use crate::error::SaphirError;
     ///
     pub use crate::handler::Handler;
+    #[cfg(feature = "operation")]
+    pub use crate::http_context::operation::OperationId;
     ///
     pub use crate::http_context::HttpContext;
     ///

--- a/saphir/src/request.rs
+++ b/saphir/src/request.rs
@@ -14,6 +14,9 @@ use crate::{
     error::SaphirError,
 };
 
+#[cfg(feature = "operation")]
+use crate::http_context::operation::OperationId;
+
 /// Struct that wraps a hyper request + some magic
 pub struct Request<T = Body<Bytes>> {
     #[doc(hidden)]
@@ -24,6 +27,9 @@ pub struct Request<T = Body<Bytes>> {
     cookies: CookieJar,
     #[doc(hidden)]
     peer_addr: Option<SocketAddr>,
+    #[doc(hidden)]
+    #[cfg(feature = "operation")]
+    operation_id: OperationId,
 }
 
 impl<T> Request<T> {
@@ -34,6 +40,8 @@ impl<T> Request<T> {
             captures: Default::default(),
             cookies: Default::default(),
             peer_addr,
+            #[cfg(feature = "operation")]
+            operation_id: OperationId::with_bytes([0u8; 16]),
         }
     }
 
@@ -42,6 +50,20 @@ impl<T> Request<T> {
     #[inline]
     pub fn peer_addr(&self) -> Option<&SocketAddr> {
         self.peer_addr.as_ref()
+    }
+
+    /// Return the OperationId of the request
+    #[inline]
+    #[cfg(feature = "operation")]
+    pub fn operation_id(&self) -> &OperationId {
+        &self.operation_id
+    }
+
+    /// Return the mutable OperationId of the request
+    #[inline]
+    #[cfg(feature = "operation")]
+    pub fn operation_id_mut(&mut self) -> &mut OperationId {
+        &mut self.operation_id
     }
 
     ///
@@ -135,12 +157,17 @@ impl<T> Request<T> {
             captures,
             cookies,
             peer_addr,
+            #[cfg(feature = "operation")]
+            operation_id,
         } = self;
+
         Request {
             inner: inner.map(f),
             captures,
             cookies,
             peer_addr,
+            #[cfg(feature = "operation")]
+            operation_id,
         }
     }
 
@@ -164,6 +191,8 @@ impl<T> Request<T> {
             captures,
             cookies,
             peer_addr,
+            #[cfg(feature = "operation")]
+            operation_id,
         } = self;
         let (head, body) = inner.into_parts();
         let mapped = f(body).await;
@@ -174,6 +203,8 @@ impl<T> Request<T> {
             captures,
             cookies,
             peer_addr,
+            #[cfg(feature = "operation")]
+            operation_id,
         }
     }
 
@@ -213,6 +244,8 @@ impl<T: FromBytes + Unpin + 'static> Request<Body<T>> {
             captures,
             cookies,
             peer_addr,
+            #[cfg(feature = "operation")]
+            operation_id,
         } = self;
         let (head, body) = inner.into_parts();
 
@@ -225,6 +258,8 @@ impl<T: FromBytes + Unpin + 'static> Request<Body<T>> {
             captures,
             cookies,
             peer_addr,
+            #[cfg(feature = "operation")]
+            operation_id,
         })
     }
 }
@@ -247,6 +282,8 @@ impl<T, E> Request<Result<T, E>> {
             captures,
             cookies,
             peer_addr,
+            #[cfg(feature = "operation")]
+            operation_id,
         } = self;
         let (head, body) = inner.into_parts();
 
@@ -255,6 +292,8 @@ impl<T, E> Request<Result<T, E>> {
             captures,
             cookies,
             peer_addr,
+            #[cfg(feature = "operation")]
+            operation_id,
         })
     }
 }
@@ -276,6 +315,8 @@ impl<T> Request<Option<T>> {
             captures,
             cookies,
             peer_addr,
+            #[cfg(feature = "operation")]
+            operation_id,
         } = self;
         let (head, body) = inner.into_parts();
 
@@ -284,6 +325,8 @@ impl<T> Request<Option<T>> {
             captures,
             cookies,
             peer_addr,
+            #[cfg(feature = "operation")]
+            operation_id,
         })
     }
 }

--- a/saphir/src/responder.rs
+++ b/saphir/src/responder.rs
@@ -90,7 +90,7 @@ impl Responder for StatusCode {
 impl<T: Responder> Responder for Option<T> {
     fn respond_with_builder(self, builder: Builder) -> Builder {
         if let Some(r) = self {
-            r.respond_with_builder(builder.status(200))
+            r.respond_with_builder(builder.status_if_not_set(200))
         } else {
             builder.status(404)
         }

--- a/saphir/src/responder.rs
+++ b/saphir/src/responder.rs
@@ -2,6 +2,7 @@
 use crate::{
     body::Body,
     error::SaphirError,
+    http_context::HttpContext,
     response::{Builder, Response},
 };
 use http::StatusCode;
@@ -10,7 +11,7 @@ macro_rules! impl_status_responder {
     ( $( $x:ty ),+ ) => {
         $(
             impl Responder for $x {
-                fn respond_with_builder(self, builder: Builder) -> Builder {
+                fn respond_with_builder(self, builder: Builder, _ctx: &HttpContext) -> Builder {
                     builder.status(self as u16)
                 }
             }
@@ -22,7 +23,7 @@ macro_rules! impl_body_responder {
     ( $( $x:ty ),+ ) => {
         $(
             impl Responder for $x {
-                fn respond_with_builder(self, builder: Builder) -> Builder {
+                fn respond_with_builder(self, builder: Builder, _ctx: &HttpContext) -> Builder {
                     builder.body(self)
                 }
             }
@@ -34,7 +35,7 @@ macro_rules! impl_plain_body_responder {
     ( $( $x:ty ),+ ) => {
         $(
             impl Responder for $x {
-                fn respond_with_builder(self, builder: Builder) -> Builder {
+                fn respond_with_builder(self, builder: Builder, _ctx: &HttpContext) -> Builder {
                     builder.header(http::header::CONTENT_TYPE, "text/plain").body(self)
                 }
             }
@@ -47,8 +48,8 @@ macro_rules! impl_tuple_responder {
     ( $($idx:tt -> $T:ident),+ ) => {
 
             impl<$($T:Responder),+> Responder for ($($T),+) {
-                fn respond_with_builder(self, builder: Builder) -> Builder {
-                    $(let builder = self.$idx.respond_with_builder(builder);)+
+                fn respond_with_builder(self, builder: Builder, ctx: &HttpContext) -> Builder {
+                    $(let builder = self.$idx.respond_with_builder(builder, ctx);)+
                     builder
                 }
             }
@@ -64,33 +65,33 @@ pub trait Responder {
     /// struct CustomResponder(String);
     ///
     /// impl Responder for CustomResponder {
-    ///     fn respond_with_builder(self, builder: Builder) -> Builder {
+    ///     fn respond_with_builder(self, builder: Builder, ctx: &HttpContext) -> Builder {
     ///         // Put the string as the response body
     ///         builder.body(self.0)
     ///     }
     /// }
     /// ```
-    fn respond_with_builder(self, builder: Builder) -> Builder;
+    fn respond_with_builder(self, builder: Builder, ctx: &HttpContext) -> Builder;
 
     ///
-    fn respond(self) -> Result<Response<Body>, SaphirError>
+    fn respond(self, ctx: &HttpContext) -> Result<Response<Body>, SaphirError>
     where
         Self: Sized,
     {
-        self.respond_with_builder(Builder::new()).build()
+        self.respond_with_builder(Builder::new(), ctx).build()
     }
 }
 
 impl Responder for StatusCode {
-    fn respond_with_builder(self, builder: Builder) -> Builder {
+    fn respond_with_builder(self, builder: Builder, _ctx: &HttpContext) -> Builder {
         builder.status(self)
     }
 }
 
 impl<T: Responder> Responder for Option<T> {
-    fn respond_with_builder(self, builder: Builder) -> Builder {
+    fn respond_with_builder(self, builder: Builder, ctx: &HttpContext) -> Builder {
         if let Some(r) = self {
-            r.respond_with_builder(builder.status_if_not_set(200))
+            r.respond_with_builder(builder.status_if_not_set(200), ctx)
         } else {
             builder.status(404)
         }
@@ -98,22 +99,22 @@ impl<T: Responder> Responder for Option<T> {
 }
 
 impl<T: Responder, E: Responder> Responder for Result<T, E> {
-    fn respond_with_builder(self, builder: Builder) -> Builder {
+    fn respond_with_builder(self, builder: Builder, ctx: &HttpContext) -> Builder {
         match self {
-            Ok(r) => r.respond_with_builder(builder),
-            Err(r) => r.respond_with_builder(builder),
+            Ok(r) => r.respond_with_builder(builder, ctx),
+            Err(r) => r.respond_with_builder(builder, ctx),
         }
     }
 }
 
 impl Responder for hyper::Error {
-    fn respond_with_builder(self, builder: Builder) -> Builder {
+    fn respond_with_builder(self, builder: Builder, _ctx: &HttpContext) -> Builder {
         builder.status(500)
     }
 }
 
 impl Responder for Builder {
-    fn respond_with_builder(self, _builder: Builder) -> Builder {
+    fn respond_with_builder(self, _builder: Builder, _ctx: &HttpContext) -> Builder {
         self
     }
 }
@@ -125,7 +126,7 @@ mod json {
     use serde::Serialize;
 
     impl<T: Serialize> Responder for Json<T> {
-        fn respond_with_builder(self, builder: Builder) -> Builder {
+        fn respond_with_builder(self, builder: Builder, _ctx: &HttpContext) -> Builder {
             let b = match builder.json(&self.0) {
                 Ok(b) => b,
                 Err((b, _e)) => b.status(500).body("Unable to serialize json data"),
@@ -142,7 +143,7 @@ mod form {
     use serde::Serialize;
 
     impl<T: Serialize> Responder for Form<T> {
-        fn respond_with_builder(self, builder: Builder) -> Builder {
+        fn respond_with_builder(self, builder: Builder, _ctx: &HttpContext) -> Builder {
             let b = match builder.form(&self.0) {
                 Ok(b) => b,
                 Err((b, _e)) => b.status(500).body("Unable to serialize form data"),
@@ -164,14 +165,14 @@ impl_tuple_responder!(0->A, 1->B, 2->C, 3->D, 4->E, 5->F);
 /// Trait used by the server, not meant for manual implementation
 pub trait DynResponder {
     #[doc(hidden)]
-    fn dyn_respond(&mut self) -> Result<Response<Body>, SaphirError>;
+    fn dyn_respond(&mut self, ctx: &HttpContext) -> Result<Response<Body>, SaphirError>;
 }
 
 impl<T> DynResponder for Option<T>
 where
     T: Responder,
 {
-    fn dyn_respond(&mut self) -> Result<Response<Body>, SaphirError> {
-        self.take().ok_or(500).respond()
+    fn dyn_respond(&mut self, ctx: &HttpContext) -> Result<Response<Body>, SaphirError> {
+        self.take().ok_or(500).respond(ctx)
     }
 }

--- a/saphir/src/response.rs
+++ b/saphir/src/response.rs
@@ -14,8 +14,10 @@ use crate::{
 };
 
 /// Struct that wraps a hyper response + some magic
-pub struct Response<T> {
+pub struct Response<T = Body> {
+    #[doc(hidden)]
     inner: RawResponse<T>,
+    #[doc(hidden)]
     cookies: CookieJar,
 }
 
@@ -90,9 +92,13 @@ impl<T> DerefMut for Response<T> {
 
 /// Struct used to conveniently build a response
 pub struct Builder {
+    #[doc(hidden)]
     inner: RawBuilder,
+    #[doc(hidden)]
     cookies: Option<CookieJar>,
+    #[doc(hidden)]
     body: Box<dyn TransmuteBody + Send + Sync>,
+    #[doc(hidden)]
     status_set: bool,
 }
 
@@ -118,7 +124,7 @@ impl Builder {
     }
 
     #[inline]
-    pub(crate) fn status_if_not_set<T>(mut self, status: T) -> Builder
+    pub(crate) fn status_if_not_set<T>(self, status: T) -> Builder
     where
         StatusCode: TryFrom<T>,
         <StatusCode as TryFrom<T>>::Error: Into<http::Error>,
@@ -302,7 +308,7 @@ impl Builder {
             inner,
             cookies,
             mut body,
-            status_set,
+            status_set: _,
         } = self;
         let b = body.transmute();
         let raw = inner.body(b)?;


### PR DESCRIPTION
This PR Adds the following:

- Operation ID under the operation feature
- Middleware chain consume and return a Context instead of a response
- Responders can now access the HttpContext
- Server ID can be configured