### PR TITLE
Feature/408 request timeout

### DIFF
--- a/saphir/Cargo.toml
+++ b/saphir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saphir"
-version = "2.7.3"
+version = "2.7.4"
 edition = "2018"
 authors = ["Richer Archambault <richer.arc@gmail.com>"]
 description = "Fully async-await http server framework"

--- a/saphir/src/error.rs
+++ b/saphir/src/error.rs
@@ -56,6 +56,8 @@ pub enum SaphirError {
     MissingParameter(String, bool),
     ///
     InvalidParameter(String, bool),
+    ///
+    RequestTimeout,
 }
 
 impl Debug for SaphirError {
@@ -77,6 +79,7 @@ impl Debug for SaphirError {
             SaphirError::SerdeUrlSer(d) => std::fmt::Debug::fmt(d, f),
             SaphirError::MissingParameter(d, _) => std::fmt::Debug::fmt(d, f),
             SaphirError::InvalidParameter(d, _) => std::fmt::Debug::fmt(d, f),
+            SaphirError::RequestTimeout => f.write_str("RequestTimeout"),
         }
     }
 }
@@ -227,6 +230,10 @@ impl Responder for SaphirError {
                 builder.status(500)
             }
             SaphirError::Responder(mut r) => r.dyn_respond(builder, ctx),
+            SaphirError::RequestTimeout => {
+                warn!("{}Request timed out", op_id);
+                builder.status(408)
+            }
         }
     }
 }

--- a/saphir/src/error.rs
+++ b/saphir/src/error.rs
@@ -178,7 +178,7 @@ impl SaphirError {
             SaphirError::RequestTimeout => {
                 warn!("{}Request timed out", op_id);
             }
-            SaphirError::Responder(_) => {},
+            SaphirError::Responder(_) => {}
         }
     }
 }

--- a/saphir/src/error.rs
+++ b/saphir/src/error.rs
@@ -88,6 +88,99 @@ impl SaphirError {
     pub fn responder<T: Responder + Send + Sync + 'static>(e: T) -> Self {
         SaphirError::Responder(Box::new(Some(e)))
     }
+
+    pub(crate) fn response_builder(self, builder: Builder, ctx: &HttpContext) -> Builder {
+        match self {
+            SaphirError::Internal(_) => builder.status(500),
+            SaphirError::Io(_) => builder.status(500),
+            SaphirError::BodyAlreadyTaken => builder.status(500),
+            SaphirError::Custom(_) => builder.status(500),
+            SaphirError::Other(_) => builder.status(500),
+            #[cfg(feature = "json")]
+            SaphirError::SerdeJson(_) => builder.status(400),
+            #[cfg(feature = "form")]
+            SaphirError::SerdeUrlDe(_) => builder.status(400),
+            #[cfg(feature = "form")]
+            SaphirError::SerdeUrlSer(_) => builder.status(400),
+            SaphirError::MissingParameter(..) => builder.status(400),
+            SaphirError::InvalidParameter(..) => builder.status(400),
+            SaphirError::RequestMovedBeforeHandler => builder.status(500),
+            SaphirError::ResponseMoved => builder.status(500),
+            SaphirError::Responder(mut r) => r.dyn_respond(builder, ctx),
+            SaphirError::RequestTimeout => builder.status(408),
+        }
+    }
+
+    pub(crate) fn log(&self, ctx: &HttpContext) {
+        let op_id = {
+            #[cfg(not(feature = "operation"))]
+            {
+                String::new()
+            }
+
+            #[cfg(feature = "operation")]
+            {
+                format!("[Operation id: {}] ", ctx.operation_id)
+            }
+        };
+
+        match self {
+            SaphirError::Internal(e) => {
+                warn!("{}Saphir encountered an internal error that was returned as a responder: {:?}", op_id, e);
+            }
+            SaphirError::Io(e) => {
+                warn!("{}Saphir encountered an Io error that was returned as a responder: {:?}", op_id, e);
+            }
+            SaphirError::BodyAlreadyTaken => {
+                warn!("{}A controller handler attempted to take the request body more thant one time", op_id);
+            }
+            SaphirError::Custom(e) => {
+                warn!("{}A custom error was returned as a responder: {:?}", op_id, e);
+            }
+            SaphirError::Other(e) => {
+                warn!("{}Saphir encountered an Unknown error that was returned as a responder: {:?}", op_id, e);
+            }
+            #[cfg(feature = "json")]
+            SaphirError::SerdeJson(e) => {
+                debug!("{}Unable to de/serialize json type: {:?}", op_id, e);
+            }
+            #[cfg(feature = "form")]
+            SaphirError::SerdeUrlDe(e) => {
+                debug!("{}Unable to deserialize form type: {:?}", op_id, e);
+            }
+            #[cfg(feature = "form")]
+            SaphirError::SerdeUrlSer(e) => {
+                debug!("{}Unable to serialize form type: {:?}", op_id, e);
+            }
+            SaphirError::MissingParameter(name, is_query) => {
+                if *is_query {
+                    debug!("{}Missing query parameter {}", op_id, name);
+                } else {
+                    debug!("{}Missing path parameter {}", op_id, name);
+                }
+            }
+            SaphirError::InvalidParameter(name, is_query) => {
+                if *is_query {
+                    debug!("{}Unable to parse query parameter {}", op_id, name);
+                } else {
+                    debug!("{}Unable to parse path parameter {}", op_id, name);
+                }
+            }
+            SaphirError::RequestMovedBeforeHandler => {
+                warn!(
+                    "{}A request was moved out of its context by a middleware, but the middleware did not stop request processing",
+                    op_id
+                );
+            }
+            SaphirError::ResponseMoved => {
+                warn!("{}A response was moved before being sent to the client", op_id);
+            }
+            SaphirError::RequestTimeout => {
+                warn!("{}Request timed out", op_id);
+            }
+            SaphirError::Responder(_) => {},
+        }
+    }
 }
 
 #[cfg(feature = "json")]
@@ -152,88 +245,7 @@ impl StdError for SaphirError {}
 impl Responder for SaphirError {
     #[allow(unused_variables)]
     fn respond_with_builder(self, builder: Builder, ctx: &HttpContext) -> Builder {
-        let op_id = {
-            #[cfg(not(feature = "operation"))]
-            {
-                String::new()
-            }
-
-            #[cfg(feature = "operation")]
-            {
-                format!("[Operation id: {}] ", ctx.operation_id)
-            }
-        };
-
-        match self {
-            SaphirError::Internal(e) => {
-                warn!("{}Saphir encountered an internal error that was returned as a responder: {:?}", op_id, e);
-                builder.status(500)
-            }
-            SaphirError::Io(e) => {
-                warn!("{}Saphir encountered an Io error that was returned as a responder: {:?}", op_id, e);
-                builder.status(500)
-            }
-            SaphirError::BodyAlreadyTaken => {
-                warn!("{}A controller handler attempted to take the request body more thant one time", op_id);
-                builder.status(500)
-            }
-            SaphirError::Custom(e) => {
-                warn!("{}A custom error was returned as a responder: {:?}", op_id, e);
-                builder.status(500)
-            }
-            SaphirError::Other(e) => {
-                warn!("{}Saphir encountered an Unknown error that was returned as a responder: {:?}", op_id, e);
-                builder.status(500)
-            }
-            #[cfg(feature = "json")]
-            SaphirError::SerdeJson(e) => {
-                debug!("{}Unable to de/serialize json type: {:?}", op_id, e);
-                builder.status(400)
-            }
-            #[cfg(feature = "form")]
-            SaphirError::SerdeUrlDe(e) => {
-                debug!("{}Unable to deserialize form type: {:?}", op_id, e);
-                builder.status(400)
-            }
-            #[cfg(feature = "form")]
-            SaphirError::SerdeUrlSer(e) => {
-                debug!("{}Unable to serialize form type: {:?}", op_id, e);
-                builder.status(400)
-            }
-            SaphirError::MissingParameter(name, is_query) => {
-                if is_query {
-                    debug!("{}Missing query parameter {}", op_id, name);
-                } else {
-                    debug!("{}Missing path parameter {}", op_id, name);
-                }
-
-                builder.status(400)
-            }
-            SaphirError::InvalidParameter(name, is_query) => {
-                if is_query {
-                    debug!("{}Unable to parse query parameter {}", op_id, name);
-                } else {
-                    debug!("{}Unable to parse path parameter {}", op_id, name);
-                }
-
-                builder.status(400)
-            }
-            SaphirError::RequestMovedBeforeHandler => {
-                warn!(
-                    "{}A request was moved out of its context by a middleware, but the middleware did not stop request processing",
-                    op_id
-                );
-                builder.status(500)
-            }
-            SaphirError::ResponseMoved => {
-                warn!("{}A response was moved before being sent to the client", op_id);
-                builder.status(500)
-            }
-            SaphirError::Responder(mut r) => r.dyn_respond(builder, ctx),
-            SaphirError::RequestTimeout => {
-                warn!("{}Request timed out", op_id);
-                builder.status(408)
-            }
-        }
+        self.log(ctx);
+        self.response_builder(builder, ctx)
     }
 }

--- a/saphir/src/http_context.rs
+++ b/saphir/src/http_context.rs
@@ -243,7 +243,7 @@ impl HttpContext {
             router: self.router.clone(),
             metadata: self.metadata.clone(),
             #[cfg(feature = "operation")]
-            operation_id: self.operation_id.clone(),
+            operation_id: self.operation_id,
         }
     }
 

--- a/saphir/src/http_context.rs
+++ b/saphir/src/http_context.rs
@@ -237,6 +237,16 @@ impl HttpContext {
         }
     }
 
+    pub fn clone_with_empty_state(&self) -> Self {
+        HttpContext {
+            state: State::Empty,
+            router: self.router.clone(),
+            metadata: self.metadata.clone(),
+            #[cfg(feature = "operation")]
+            operation_id: self.operation_id.clone(),
+        }
+    }
+
     /// Explicitly set the inner state to `Before` with the given response
     pub fn before(&mut self, request: Request) {
         self.state = State::Before(Box::new(request))

--- a/saphir/src/http_context.rs
+++ b/saphir/src/http_context.rs
@@ -1,5 +1,4 @@
-use crate::{request::Request, response::Response, router::Router};
-use crate::body::Body;
+use crate::{body::Body, request::Request, response::Response, router::Router};
 
 #[cfg(feature = "operation")]
 pub static OPERATION_ID_HEADER: &str = "Operation-Id";

--- a/saphir/src/http_context.rs
+++ b/saphir/src/http_context.rs
@@ -1,4 +1,4 @@
-use crate::{body::Body, request::Request, response::Response, router::Router};
+use crate::{request::Request, response::Response, router::Router};
 
 #[cfg(feature = "operation")]
 pub static OPERATION_ID_HEADER: &str = "Operation-Id";
@@ -8,19 +8,19 @@ pub static OPERATION_ID_HEADER: &str = "Operation-Id";
 /// responder. Empty will be the state of a context when the request is being
 /// processed by the handler, or when its original state has been moved by using
 /// take & take unchecked methods
-pub enum State<T = Body> {
-    Before(Box<Request<T>>),
+pub enum State {
+    Before(Box<Request>),
     After(Box<Response>),
     Empty,
 }
 
-impl<T> Default for State<T> {
+impl Default for State {
     fn default() -> Self {
         State::Empty
     }
 }
 
-impl<T> State<T> {
+impl State {
     /// Take the current context leaving `State::Empty` behind
     pub fn take(&mut self) -> Self {
         std::mem::take(self)
@@ -29,7 +29,7 @@ impl<T> State<T> {
     /// Take the current request leaving `State::Empty` behind
     /// Returns `Some(Request)` if the state was `Before` or `None` if it was
     /// something else
-    pub fn take_request(&mut self) -> Option<Request<T>> {
+    pub fn take_request(&mut self) -> Option<Request> {
         match std::mem::take(self) {
             State::Before(r) => Some(*r),
             _ => None,
@@ -40,7 +40,7 @@ impl<T> State<T> {
     ///
     /// # Panics
     /// Panics if the state is not `Before`
-    pub fn take_request_unchecked(&mut self) -> Request<T> {
+    pub fn take_request_unchecked(&mut self) -> Request {
         match std::mem::take(self) {
             State::Before(r) => *r,
             _ => panic!("State::take_request_unchecked should be called only before the handler & when it is ensured that the request wasn't moved"),
@@ -69,7 +69,7 @@ impl<T> State<T> {
     }
 
     /// Returns `Some` of the current request if state if `Before`
-    pub fn request(&self) -> Option<&Request<T>> {
+    pub fn request(&self) -> Option<&Request> {
         match self {
             State::Before(r) => Some(r),
             _ => None,
@@ -78,7 +78,7 @@ impl<T> State<T> {
 
     /// Returns `Some` of the current request as a mutable ref if state if
     /// `Before`
-    pub fn request_mut(&mut self) -> Option<&Request<T>> {
+    pub fn request_mut(&mut self) -> Option<&Request> {
         match self {
             State::Before(r) => Some(r),
             _ => None,
@@ -89,7 +89,7 @@ impl<T> State<T> {
     ///
     /// # Panics
     /// Panics if state is not `Before`
-    pub fn request_unchecked(&self) -> &Request<T> {
+    pub fn request_unchecked(&self) -> &Request {
         match self {
             State::Before(r) => r,
             _ => panic!("State::request_unchecked should be called only before the handler & when it is ensured that the request wasn't moved"),
@@ -100,7 +100,7 @@ impl<T> State<T> {
     ///
     /// # Panics
     /// panics if state is not `Before`
-    pub fn request_unchecked_mut(&mut self) -> &mut Request<T> {
+    pub fn request_unchecked_mut(&mut self) -> &mut Request {
         match self {
             State::Before(r) => r,
             _ => panic!("State::request_unchecked_mut should be called only before the handler & when it is ensured that the request wasn't moved"),

--- a/saphir/src/request.rs
+++ b/saphir/src/request.rs
@@ -55,6 +55,17 @@ impl<T> Request<T> {
         }
     }
 
+    pub(crate) fn clone_for_err(req: &Self) -> Request<Body> {
+        Request::<Body> {
+            inner: RawRequest::new(Body::empty()),
+            captures: req.captures.clone(),
+            cookies: req.cookies.clone(),
+            peer_addr: req.peer_addr.clone(),
+            #[cfg(feature = "operation")]
+            operation_id: req.operation_id.clone(),
+        }
+    }
+
     /// Return the Peer SocketAddr if one was available when receiving the
     /// request
     #[inline]

--- a/saphir/src/request.rs
+++ b/saphir/src/request.rs
@@ -60,9 +60,9 @@ impl<T> Request<T> {
             inner: RawRequest::new(Body::empty()),
             captures: req.captures.clone(),
             cookies: req.cookies.clone(),
-            peer_addr: req.peer_addr.clone(),
+            peer_addr: req.peer_addr,
             #[cfg(feature = "operation")]
-            operation_id: req.operation_id.clone(),
+            operation_id: req.operation_id,
         }
     }
 

--- a/saphir/src/request.rs
+++ b/saphir/src/request.rs
@@ -55,17 +55,6 @@ impl<T> Request<T> {
         }
     }
 
-    pub(crate) fn clone_for_err(req: &Self) -> Request<Body> {
-        Request::<Body> {
-            inner: RawRequest::new(Body::empty()),
-            captures: req.captures.clone(),
-            cookies: req.cookies.clone(),
-            peer_addr: req.peer_addr,
-            #[cfg(feature = "operation")]
-            operation_id: req.operation_id,
-        }
-    }
-
     /// Return the Peer SocketAddr if one was available when receiving the
     /// request
     #[inline]

--- a/saphir/src/router.rs
+++ b/saphir/src/router.rs
@@ -217,7 +217,7 @@ impl Router {
         }
     }
 
-    pub fn resolve_metadata(&self, req: &mut Request<Body>) -> HandlerMetadata {
+    pub fn resolve_metadata(&self, req: &mut Request) -> HandlerMetadata {
         let mut method_not_allowed = false;
 
         for endpoint_resolver in &self.inner.resolvers {

--- a/saphir/src/server.rs
+++ b/saphir/src/server.rs
@@ -445,9 +445,11 @@ pub struct StackHandler {
     peer_addr: Option<SocketAddr>,
 }
 
+type StackHandlerFut<S, E> = dyn Future<Output = Result<S, E>> + Send;
+
 impl Service<hyper::Request<hyper::Body>> for StackHandler {
     type Error = SaphirError;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+    type Future = Pin<Box<StackHandlerFut<Self::Response, Self::Error>>>;
     type Response = hyper::Response<hyper::Body>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/saphir/src/server.rs
+++ b/saphir/src/server.rs
@@ -29,7 +29,6 @@ use crate::{
 };
 use http::{HeaderValue, Request as RawRequest, Response as RawResponse};
 use std::pin::Pin;
-use crate::responder::Responder;
 
 /// Default time for request handling is 30 seconds
 pub const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 30_000;
@@ -428,7 +427,11 @@ impl Stack {
             let meta = self.router.resolve_metadata(&mut err_req);
             let ctx = HttpContext::new(err_req, self.router.clone(), meta);
             let builder = crate::response::Builder::new();
-            e.respond_with_builder(builder, &ctx).build()
+            e.log(&ctx);
+            e.response_builder(builder, &ctx).build().map_err(|e2| {
+                e2.log(&ctx);
+                e2
+            })
         })
     }
 }


### PR DESCRIPTION
- Always completely poll the Service future passed to Hyper.
- Wrap the inner invoke inside the Service in a tokio Timeout
- Return a `SaphirError::RequestTimeout` on timeout (returning a 408 Request Timeout)
- Attempt to return an HTTP response when invocation produce a SaphirError
- Properly log the SaphirError even if building a HTTP response out of it fail