### PR TITLE
Fixed Send requirement for graceful shutdown future

### DIFF
--- a/saphir/src/middleware.rs
+++ b/saphir/src/middleware.rs
@@ -171,7 +171,7 @@ impl MiddlewareChain for MiddleChainEnd {
     #[inline]
     fn next(&self, mut ctx: HttpContext) -> BoxFuture<'static, Result<HttpContext, SaphirError>> {
         async {
-            let router = ctx.router.take().ok_or_else(|| SaphirError::Internal(InternalError::Stack))?;
+            let router = ctx.router.take().ok_or(SaphirError::Internal(InternalError::Stack))?;
             router.dispatch(ctx).await
         }
         .boxed()

--- a/saphir/src/multipart/parser.rs
+++ b/saphir/src/multipart/parser.rs
@@ -132,8 +132,7 @@ fn headers(input: &[u8]) -> IResult<&[u8], FieldHeaders> {
         }
     }
 
-    let (content_disposition_name, content_disposition_filename) =
-        content_disposition.ok_or_else(|| nom::Err::Error((input, nom::error::ErrorKind::MapOpt)))?;
+    let (content_disposition_name, content_disposition_filename) = content_disposition.ok_or(nom::Err::Error((input, nom::error::ErrorKind::MapOpt)))?;
 
     Ok((
         input,

--- a/saphir/src/server.rs
+++ b/saphir/src/server.rs
@@ -217,7 +217,7 @@ impl ListenerBuilder {
             request_timeout_ms,
             server_name: server_name.unwrap_or_else(|| DEFAULT_SERVER_NAME.to_string()),
             request_body_max,
-            shutdown
+            shutdown,
         }
     }
 }

--- a/saphir/src/server.rs
+++ b/saphir/src/server.rs
@@ -76,7 +76,7 @@ pub struct ListenerBuilder {
     cert_config: Option<SslConfig>,
     #[cfg(feature = "https")]
     key_config: Option<SslConfig>,
-    shutdown_signal: Option<Box<dyn Future<Output = ()> + Unpin + 'static>>,
+    shutdown_signal: Option<Box<dyn Future<Output = ()> + Unpin + Send + 'static>>,
     graceful_shutdown: bool,
 }
 
@@ -131,7 +131,7 @@ impl ListenerBuilder {
     /// request to be completed before shutting down but will stop accepting
     /// new requests.
     #[inline]
-    pub fn shutdown<F: Future<Output = ()> + Unpin + 'static>(mut self, signal: F, graceful: bool) -> Self {
+    pub fn shutdown<F: Future<Output = ()> + Unpin + Send + 'static>(mut self, signal: F, graceful: bool) -> Self {
         self.shutdown_signal = Some(Box::new(signal));
         self.graceful_shutdown = graceful;
         self
@@ -330,11 +330,11 @@ impl SeverShutdownState {
 struct ServerShutdown {
     graceful: bool,
     state: Arc<SeverShutdownState>,
-    signal: Pin<Box<dyn Future<Output = ()> + Unpin + 'static>>,
+    signal: Pin<Box<dyn Future<Output = ()> + Unpin + Send + 'static>>,
 }
 
 impl ServerShutdown {
-    pub fn new<F: Future<Output = ()> + Unpin + 'static>(graceful: bool, signal: F) -> Self {
+    pub fn new<F: Future<Output = ()> + Unpin + Send + 'static>(graceful: bool, signal: F) -> Self {
         ServerShutdown {
             graceful,
             state: Arc::new(Default::default()),


### PR DESCRIPTION
This PR adds the missing `Send` requirement for shutdown future which is required to make tokio::spawn with Saphir server future possible

fixes #125 