### PR TITLE
File middleware now handles HEAD requests correctly

### DIFF
--- a/saphir/src/file/cache.rs
+++ b/saphir/src/file/cache.rs
@@ -112,11 +112,7 @@ impl FileCache {
             file_stream.set_range(range).await?;
             Ok(file_stream)
         } else {
-            let mut file_stream = FileStream::new(FileCacher::new(
-                (path_str.to_string(), Compression::Raw),
-                Box::pin(File::open(path_str).await?),
-                self.clone(),
-            ));
+            let mut file_stream = FileStream::new(File::open(path_str).await?);
             file_stream.set_range(range).await?;
             Ok(file_stream)
         }

--- a/saphir/src/file/middleware.rs
+++ b/saphir/src/file/middleware.rs
@@ -145,7 +145,7 @@ impl FileMiddleware {
                 if let Some(range) = extract_range(&content_range) {
                     if !is_head_request {
                         let file = cache.open_file_with_range(&path, range).await?;
-                        size = file.get_size();
+                        size = (range.1 - range.0) + 1;
                         builder = builder.file(file);
                     }
                 }

--- a/saphir/src/file/mod.rs
+++ b/saphir/src/file/mod.rs
@@ -327,7 +327,7 @@ impl FileStream {
     pub async fn set_range(&mut self, range: (u64, u64)) -> io::Result<()> {
         let (start, end) = range;
         self.inner.seek(SeekFrom::Start(start)).await?;
-        self.range_len = Some(end - start);
+        self.range_len = Some((end - start) + 1);
         Ok(())
     }
 


### PR DESCRIPTION
Skips file reading for HEAD requests and return an empty body in file middleware

Closes #141