### PR TITLE
Tokio 1.5 hyper 0.14

### DIFF
--- a/saphir/Cargo.toml
+++ b/saphir/Cargo.toml
@@ -11,9 +11,16 @@ readme = "../README.md"
 keywords = ["hyper", "http", "server", "web", "async"]
 license = "MIT"
 
+[[example]]
+name = "basic"
+
+[[example]]
+name = "macro"
+required-features = ["json", "file", "multipart", "form"]
+
 [features]
-default = ["macro"]
-full = ["macro", "json", "form", "https", "multipart", "operation", "post-redirect", "file"]
+default = ["macro", "http1"]
+full = ["macro", "json", "form", "https", "multipart", "operation", "post-redirect", "file", "http1", "http2"]
 post-redirect = ["redirect", "json"]
 redirect = ["mime", "form"]
 https = ["base64", "rustls", "tokio-rustls"]
@@ -23,11 +30,13 @@ macro = ["saphir_macro"]
 multipart = ["mime", "nom"]
 file = ["mime", "mime_guess", "percent-encoding", "chrono", "flate2", "brotli"]
 operation = ["serde", "uuid"]
+http1 = ["hyper/http1"]
+http2 = ["hyper/http2"]
 
 [dependencies]
 log = "0.4"
-hyper = { version = "0.13.6", features = ["stream"] }
-tokio = { version = "0.2.13", features = ["full"] }
+hyper = { version = "0.14.7", features = ["stream", "server"] }
+tokio = { version = "1.5.0", features = ["full"] }
 futures = "0.3"
 futures-util = "0.3"
 tower-service = "0.3"

--- a/saphir/Cargo.toml
+++ b/saphir/Cargo.toml
@@ -34,6 +34,7 @@ http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 
 [dependencies]
+async-stream = "0.3.1"
 log = "0.4"
 hyper = { version = "0.14.7", features = ["stream", "server"] }
 tokio = { version = "1.5.0", features = ["full"] }
@@ -46,8 +47,8 @@ http-body = "0.3"
 parking_lot = "0.11"
 regex = "1.3"
 uuid = { version = "0.8", features = ["serde", "v4"], optional = true }
-rustls = { version = "0.18", optional = true }
-tokio-rustls = { version = "0.14", optional = true }
+rustls = { version = "0.19", optional = true }
+tokio-rustls = { version = "0.22", optional = true }
 base64 = { version = "0.13", optional = true }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/saphir/examples/basic.rs
+++ b/saphir/examples/basic.rs
@@ -7,6 +7,7 @@ use futures::{
 };
 use saphir::prelude::*;
 use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "operation")]
 use tokio::sync::RwLock;
 
 // == controller == //
@@ -52,7 +53,7 @@ impl Controller for MagicController {
 impl MagicController {
     async fn magic_delay(&self, req: Request) -> (u16, String) {
         if let Some(delay) = req.captures().get("delay").and_then(|t| t.parse::<u64>().ok()) {
-            tokio::time::delay_for(tokio::time::Duration::from_secs(delay)).await;
+            tokio::time::sleep(tokio::time::Duration::from_secs(delay)).await;
             (200, format!("Delayed of {} secs: {}", delay, self.label))
         } else {
             (400, "Invalid timeout".to_owned())
@@ -125,14 +126,18 @@ struct User {
 // == middleware == //
 
 struct StatsData {
+    #[cfg(feature = "operation")]
     entered: RwLock<u32>,
+    #[cfg(feature = "operation")]
     exited: RwLock<u32>,
 }
 
 impl StatsData {
     fn new() -> Self {
         Self {
+            #[cfg(feature = "operation")]
             entered: RwLock::new(0),
+            #[cfg(feature = "operation")]
             exited: RwLock::new(0),
         }
     }

--- a/saphir/src/body.rs
+++ b/saphir/src/body.rs
@@ -3,11 +3,10 @@
 use crate::error::SaphirError;
 use futures::{
     task::{Context, Poll},
-    Future,
+    Future, StreamExt,
 };
 use http::HeaderMap;
-use http_body::SizeHint;
-use hyper::body::{Body as RawBody, Buf, HttpBody};
+use hyper::body::{Body as RawBody, Buf, HttpBody, SizeHint};
 use std::pin::Pin;
 
 pub use hyper::body::Bytes;
@@ -17,7 +16,6 @@ pub use form::Form;
 #[cfg(feature = "json")]
 pub use json::Json;
 use std::ops::DerefMut;
-use tokio::stream::StreamExt;
 
 #[doc(hidden)]
 pub(crate) static mut REQUEST_BODY_BYTES_LIMIT: Option<usize> = None;
@@ -459,7 +457,7 @@ impl HttpBody for BodyInner {
     fn poll_data(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Self::Data, SaphirError>>> {
         if let BodyInner::Memory(b) = self.deref_mut() {
             if !b.is_empty() {
-                Poll::Ready(Some(Ok(b.to_bytes())))
+                Poll::Ready(Some(Ok(b.slice(..))))
             } else {
                 Poll::Ready(None)
             }

--- a/saphir/src/error.rs
+++ b/saphir/src/error.rs
@@ -7,7 +7,7 @@ use http::{
     header::{InvalidHeaderValue, ToStrError},
     Error as HttpCrateError,
 };
-use hyper::error::Error as HyperError;
+use hyper::Error as HyperError;
 use std::{
     error::Error as StdError,
     fmt::{Debug, Display, Error as FmtError, Formatter},

--- a/saphir/src/file/mod.rs
+++ b/saphir/src/file/mod.rs
@@ -8,9 +8,9 @@ use futures_util::{
 use hyper::body::Bytes;
 use tokio::{
     fs::File as TokioFile,
+    io,
     io::{AsyncRead as TokioAsyncRead, AsyncSeek as TokioAsyncSeek},
     macros::support::Pin,
-    prelude::*,
 };
 
 use crate::{error::SaphirError, file::middleware::PathExt, http_context::HttpContext, responder::Responder, response::Builder};
@@ -19,6 +19,7 @@ use futures::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, Cursor};
 use mime::Mime;
 use nom::lib::std::str::FromStr;
 use std::io::{Cursor as CursorSync, Write};
+use tokio::io::ReadBuf;
 
 mod cache;
 pub mod conditional_request;
@@ -79,19 +80,22 @@ impl File {
 
 impl AsyncRead for File {
     fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
-        self.inner.as_mut().poll_read(cx, buf)
+        let buf_len = buf.len();
+        match self.inner.as_mut().poll_read(cx, &mut ReadBuf::new(buf)) {
+            Poll::Ready(r) => Poll::Ready(r.map(|_| buf.len() - buf_len)),
+            Poll::Pending => Poll::Pending,
+        }
     }
 }
 
 impl AsyncSeek for File {
     fn poll_seek(mut self: Pin<&mut Self>, cx: &mut Context<'_>, pos: SeekFrom) -> Poll<io::Result<u64>> {
         if !self.seek_has_started {
-            match self.inner.as_mut().start_seek(cx, pos) {
-                Poll::Ready(Ok(())) => {
+            match self.inner.as_mut().start_seek(pos) {
+                Ok(()) => {
                     self.seek_has_started = true;
                 }
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                Poll::Pending => return Poll::Pending,
+                Err(e) => return Poll::Ready(Err(e)),
             }
         }
 

--- a/saphir/src/middleware.rs
+++ b/saphir/src/middleware.rs
@@ -2,7 +2,7 @@
 //! the router, allowing to continue or stop the processing of a given request
 //! by calling / omitting next.
 //!
-//! ```ignore
+//! ```text
 //!        chain.next(_)       chain.next(_)
 //!              |               |
 //!              |               |

--- a/saphir/src/multipart/mod.rs
+++ b/saphir/src/multipart/mod.rs
@@ -32,7 +32,7 @@ pub enum MultipartError {
     AlreadyConsumed,
     MissingBoundary,
     Finished,
-    Hyper(hyper::error::Error),
+    Hyper(hyper::Error),
     Io(std::io::Error),
     #[cfg(feature = "json")]
     Json(serde_json::error::Error),
@@ -45,6 +45,7 @@ impl Responder for MultipartError {
         let op_id = {
             #[cfg(not(feature = "operation"))]
             {
+                let _ = ctx;
                 String::new()
             }
 

--- a/saphir/src/multipart/parser.rs
+++ b/saphir/src/multipart/parser.rs
@@ -309,8 +309,7 @@ pub async fn parse_field_data(mut stream: FieldStream, boundary: &str) -> Result
 #[cfg(test)]
 mod tests {
     use nom::Needed;
-    use std::num::NonZeroUsize;
-    use std::str::FromStr;
+    use std::{num::NonZeroUsize, str::FromStr};
 
     use super::*;
 

--- a/saphir/src/server.rs
+++ b/saphir/src/server.rs
@@ -766,10 +766,7 @@ mod ssl_loading_utils {
     use std::{fs, io::BufReader, pin::Pin};
 
     use futures::io::Error;
-    use futures_util::{
-        stream::Stream,
-        task::{Context, Poll},
-    };
+    use futures_util::task::{Context, Poll};
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
     use crate::server::SslConfig;

--- a/saphir/src/server.rs
+++ b/saphir/src/server.rs
@@ -558,7 +558,6 @@ impl Server {
             ServerFuture::new(inc, shutdown).await;
         } else {
             let inc = stream.for_each_concurrent(None, |client| async {
-                warn!("a");
                 if !state.draining() {
                     match client {
                         Ok((client_socket, peer_addr)) => {

--- a/saphir/src/server.rs
+++ b/saphir/src/server.rs
@@ -610,7 +610,7 @@ fn accept_client(listener: ssl_loading_utils::MaybeTlsAcceptor) -> impl Stream<I
     })
 }
 #[cfg(not(feature = "https"))]
-fn accept_client(listener: TcpListener) -> impl Stream<Item = tokio::io::Result<(TcpStream, SocketAddr)>> {
+fn accept_client(listener: TcpListener) -> impl Stream<Item = tokio::io::Result<(tokio::net::TcpStream, SocketAddr)>> {
     let (mut __yield_tx, __yield_rx) = ::async_stream::yielder::pair();
     async_stream::AsyncStream::new(__yield_rx, async move {
         loop {

--- a/saphir/src/server.rs
+++ b/saphir/src/server.rs
@@ -13,6 +13,7 @@ use futures::{
     prelude::*,
     task::{Context, Poll},
 };
+use futures_util::{future::TryFutureExt, stream::Stream};
 use hyper::{body::Body as RawBody, server::conn::Http, service::Service};
 use parking_lot::{Once, OnceState};
 use tokio::net::TcpListener;
@@ -486,7 +487,7 @@ impl Server {
         let listener = TcpListener::bind(listener_config.iface.clone()).await?;
         let local_addr = listener.local_addr()?;
 
-        let incoming = {
+        let listener = {
             #[cfg(feature = "https")]
             {
                 use crate::server::ssl_loading_utils::MaybeTlsAcceptor;
@@ -503,18 +504,16 @@ impl Server {
 
                         let acceptor = TlsAcceptor::from(arc_config);
 
-                        let inc = acceptor.accept(listener);
-
                         info!("Saphir started and listening on : https://{}", local_addr);
 
-                        MaybeTlsAcceptor::Tls(Box::pin(inc))
+                        MaybeTlsAcceptor::Tls(acceptor, listener)
                     }
                     (cert_config, key_config) if cert_config.xor(key_config).is_some() => {
                         return Err(SaphirError::Other("Invalid SSL configuration, missing cert or key".to_string()));
                     }
                     _ => {
                         info!("{} started and listening on : http://{}", &listener_config.server_name, local_addr);
-                        MaybeTlsAcceptor::Plain(Box::pin(listener))
+                        MaybeTlsAcceptor::Plain(listener)
                     }
                 }
             }
@@ -529,61 +528,95 @@ impl Server {
         let shutdown = listener_config.shutdown;
         let state = shutdown.state.clone();
 
+        let stream = accept_client(listener);
+
+        futures_util::pin_mut!(stream);
+
         if let Some(timeout_ms) = listener_config.request_timeout_ms {
-            let inc = async {
-                loop {
-                    let client = incoming.accept().await;
-                    if !state.draining() {
-                        match client {
-                            Ok((client_socket, peer_addr)) => {
-                                let http = http.clone();
-                                tokio::spawn(async move {
-                                    if let Err(e) = http
-                                        .serve_connection(client_socket, stack.new_timeout_handler(timeout_ms, Some(peer_addr)))
-                                        .await
-                                    {
-                                        error!("An error occurred while treating a request: {:?}", e);
-                                    }
-                                });
-                            }
-                            Err(e) => {
-                                warn!("incoming connection encountered an error: {}", e);
-                            }
+            let inc = stream.for_each_concurrent(None, |client| async {
+                if !state.draining() {
+                    match client {
+                        Ok((client_socket, peer_addr)) => {
+                            let http = http.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = http
+                                    .serve_connection(client_socket, stack.new_timeout_handler(timeout_ms, Some(peer_addr)))
+                                    .await
+                                {
+                                    error!("An error occurred while treating a request: {:?}", e);
+                                }
+                            });
                         }
-                    } else {
-                        debug!("Skipping incoming connection due to shutdown");
+                        Err(e) => {
+                            warn!("incoming connection encountered an error: {}", e);
+                        }
                     }
+                } else {
+                    debug!("Skipping incoming connection due to shutdown");
                 }
-            };
+            });
             ServerFuture::new(inc, shutdown).await;
         } else {
-            let inc = async {
-                loop {
-                    let client = incoming.accept().await;
-                    if !state.draining() {
-                        match client {
-                            Ok((client_socket, peer_addr)) => {
-                                let http = http.clone();
-                                tokio::spawn(async move {
-                                    if let Err(e) = http.serve_connection(client_socket, stack.new_handler(Some(peer_addr))).await {
-                                        error!("An error occurred while treating a request: {:?}", e);
-                                    }
-                                });
-                            }
-                            Err(e) => {
-                                warn!("incoming connection encountered an error: {}", e);
-                            }
+            let inc = stream.for_each_concurrent(None, |client| async {
+                warn!("a");
+                if !state.draining() {
+                    match client {
+                        Ok((client_socket, peer_addr)) => {
+                            let http = http.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = http.serve_connection(client_socket, stack.new_handler(Some(peer_addr))).await {
+                                    error!("An error occurred while treating a request: {:?}", e);
+                                }
+                            });
                         }
-                    } else {
-                        debug!("Skipping incoming connection due to shutdown");
+                        Err(e) => {
+                            warn!("incoming connection encountered an error: {}", e);
+                        }
                     }
+                } else {
+                    debug!("Skipping incoming connection due to shutdown");
                 }
-            };
+            });
             ServerFuture::new(inc, shutdown).await;
         }
 
         Ok(())
     }
+}
+
+#[cfg(feature = "https")]
+fn accept_client(listener: ssl_loading_utils::MaybeTlsAcceptor) -> impl Stream<Item = tokio::io::Result<(ssl_loading_utils::MaybeTlsStream, SocketAddr)>> {
+    use crate::server::ssl_loading_utils::{MaybeTlsAcceptor, MaybeTlsStream};
+    let (mut __yield_tx, __yield_rx) = async_stream::yielder::pair();
+
+    async_stream::AsyncStream::new(__yield_rx, async move {
+        match listener {
+            MaybeTlsAcceptor::Tls(tls_acceptor, tcp) => loop {
+                match tcp.accept().await {
+                    Ok((socket, addr)) => {
+                        let stream = tls_acceptor.accept(socket).await.map(|stream| (MaybeTlsStream::Tls(Box::pin(stream)), addr));
+                        __yield_tx.send(stream).await;
+                    }
+                    Err(e) => {
+                        warn!("incoming connection encountered an error: {}", e);
+                    }
+                }
+            },
+            MaybeTlsAcceptor::Plain(listener) => loop {
+                let stream = listener.accept().await.map(|(stream, addr)| (MaybeTlsStream::Plain(Box::pin(stream)), addr));
+                __yield_tx.send(stream).await;
+            },
+        }
+    })
+}
+#[cfg(not(feature = "https"))]
+fn accept_client(listener: TcpListener) -> impl Stream<Item = tokio::io::Result<(TcpStream, SocketAddr)>> {
+    let (mut __yield_tx, __yield_rx) = ::async_stream::yielder::pair();
+    async_stream::AsyncStream::new(__yield_rx, async move {
+        loop {
+            __yield_tx.send(listener.accept().await).await
+        }
+    })
 }
 
 #[doc(hidden)]
@@ -730,7 +763,7 @@ impl Service<hyper::Request<hyper::Body>> for TimeoutStackHandler {
 #[doc(hidden)]
 #[cfg(feature = "https")]
 mod ssl_loading_utils {
-    use std::{fs, io::BufReader, net::SocketAddr, pin::Pin};
+    use std::{fs, io::BufReader, pin::Pin};
 
     use futures::io::Error;
     use futures_util::{
@@ -740,38 +773,25 @@ mod ssl_loading_utils {
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
     use crate::server::SslConfig;
+    use tokio::net::TcpListener;
+    use tokio_rustls::TlsAcceptor;
 
     pub enum MaybeTlsStream {
         Tls(Pin<Box<tokio_rustls::server::TlsStream<tokio::net::TcpStream>>>),
         Plain(Pin<Box<tokio::net::TcpStream>>),
     }
 
-    impl MaybeTlsStream {
-        pub fn peer_addr(&self) -> Result<SocketAddr, tokio::io::Error> {
-            match self {
-                MaybeTlsStream::Tls(t) => t.as_ref().get_ref().get_ref().0.peer_addr(),
-                MaybeTlsStream::Plain(p) => p.as_ref().get_ref().peer_addr(),
-            }
-        }
-    }
-
     impl AsyncRead for MaybeTlsStream {
-        fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize, Error>> {
+        fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf) -> Poll<Result<(), Error>> {
             match self.get_mut() {
-                MaybeTlsStream::Tls(t) => {
-                    let buf_len = buf.len();
-                    match t.as_mut().poll_read(cx, &mut ReadBuf::new(buf)) {
-                        Poll::Ready(r) => Poll::Ready(r.map(|_| buf.len() - buf_len)),
-                        Poll::Pending => Poll::Pending,
-                    }
-                }
-                MaybeTlsStream::Plain(p) => {
-                    let buf_len = buf.len();
-                    match p.as_mut().poll_read(cx, &mut ReadBuf::new(buf)) {
-                        Poll::Ready(r) => Poll::Ready(r.map(|_| buf.len() - buf_len)),
-                        Poll::Pending => Poll::Pending,
-                    }
-                }
+                MaybeTlsStream::Tls(t) => match t.as_mut().poll_read(cx, buf) {
+                    Poll::Ready(r) => Poll::Ready(r),
+                    Poll::Pending => Poll::Pending,
+                },
+                MaybeTlsStream::Plain(p) => match p.as_mut().poll_read(cx, buf) {
+                    Poll::Ready(r) => Poll::Ready(r),
+                    Poll::Pending => Poll::Pending,
+                },
             }
         }
     }
@@ -799,26 +819,9 @@ mod ssl_loading_utils {
         }
     }
 
-    pub enum MaybeTlsAcceptor<S: Stream<Item = Result<tokio_rustls::server::TlsStream<tokio::net::TcpStream>, tokio::io::Error>>> {
-        Tls(Pin<Box<S>>),
-        Plain(Pin<Box<tokio::net::TcpListener>>),
-    }
-
-    impl<'a, S: Stream<Item = Result<tokio_rustls::server::TlsStream<tokio::net::TcpStream>, tokio::io::Error>>> Stream for MaybeTlsAcceptor<S> {
-        type Item = Result<MaybeTlsStream, tokio::io::Error>;
-
-        fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-            match self.get_mut() {
-                MaybeTlsAcceptor::Tls(tls) => tls
-                    .as_mut()
-                    .poll_next(cx)
-                    .map(|t| t.map(|tls_res| tls_res.map(|tls| MaybeTlsStream::Tls(Box::pin(tls))))),
-                MaybeTlsAcceptor::Plain(plain) => plain
-                    .as_mut()
-                    .poll_next(cx)
-                    .map(|t| t.map(|tls_res| tls_res.map(|tls| MaybeTlsStream::Plain(Box::pin(tls))))),
-            }
-        }
+    pub enum MaybeTlsAcceptor {
+        Tls(TlsAcceptor, TcpListener),
+        Plain(TcpListener),
     }
 
     pub fn load_certs(cert_config: &SslConfig) -> Vec<rustls::Certificate> {

--- a/saphir_macro/src/openapi/mod.rs
+++ b/saphir_macro/src/openapi/mod.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::ToTokens;
 use syn::{AttributeArgs, Error, Item, Lit, Meta, NestedMeta, Result};
 
-const MISSING_ATRIBUTE: &str = "openapi macro require at least one of the following attributes :
+const MISSING_ATTRIBUTE: &str = "openapi macro require at least one of the following attributes :
 - mime
 - name";
 
@@ -10,7 +10,7 @@ pub fn validate_openapi(args: AttributeArgs, input: Item) -> Result<TokenStream>
     match &input {
         Item::Struct(_) | Item::Enum(_) => {
             if args.is_empty() {
-                panic!(MISSING_ATRIBUTE);
+                panic!("{}", MISSING_ATTRIBUTE);
             }
         }
         _ => panic!("openapi attribute can only be placed on Struct and Enum"),
@@ -44,7 +44,7 @@ pub fn validate_openapi(args: AttributeArgs, input: Item) -> Result<TokenStream>
     }
 
     if mime.is_none() && name.is_none() {
-        panic!(MISSING_ATRIBUTE);
+        panic!("{}", MISSING_ATTRIBUTE);
     }
 
     Ok(input.to_token_stream())


### PR DESCRIPTION
This is a work of the upgrade to tokio 1.5 and hyper 0.14.

Close #157 

I added two new features, thanks to the new hyper version:

- `http1` that is enabled by default and allow to use the http/1 protocol
- `http2` that need to be enabled manualy ans allow the use of http/2

I fixed the warning in saphir_macro too.