### PR TITLE
Implement From<saphir::Request> for http::Request

### DIFF
--- a/saphir/src/request.rs
+++ b/saphir/src/request.rs
@@ -410,3 +410,9 @@ impl<T> DerefMut for Request<T> {
         &mut self.inner
     }
 }
+
+impl<T> From<Request<T>> for RawRequest<T> {
+    fn from(request: Request<T>) -> Self {
+        request.inner
+    }
+}


### PR DESCRIPTION
Downstream user can get owned access to the underlying http::Request.

Example: convert a http::Request obtained from saphir into a reqwest::Request
using [`try_from`](https://docs.rs/reqwest/0.11.4/reqwest/struct.Request.html#method.try_from).

```rust
let req: saphir::request::Request<saphir::body::Bytes> = req.load_body().await.expect("load body");
let req: saphir::request::Request<reqwest::Body> = req.map(|bytes| reqwest::Body::from(bytes));
let req: http::Request<reqwest::Body> = http::Request::from(req);
let req = reqwest::Request::try_from(req).expect("reqwest request");
```