### PR TITLE
Update tokio, hyper and http related dependencies

### DIFF
--- a/saphir/Cargo.toml
+++ b/saphir/Cargo.toml
@@ -50,7 +50,7 @@ serde_json = { version = "1.0", optional = true }
 serde_urlencoded = { version = "0.7", optional = true }
 saphir_macro = { path = "../saphir_macro", version = "2.1.1", optional = true }
 mime = { version = "0.3", optional = true }
-nom = { version = "6.2.1", optional = true }
+nom = { version = "6.2.1", optional = true, default-features = false }
 mime_guess = { version = "2.0.3", optional = true }
 percent-encoding = { version = "2.1.0", optional = true }
 chrono = { version = "0.4.11", optional = true }

--- a/saphir/Cargo.toml
+++ b/saphir/Cargo.toml
@@ -30,19 +30,20 @@ operation = ["serde", "uuid"]
 
 [dependencies]
 log = "0.4"
-hyper = { version = "0.13.6", features = ["stream"] }
-tokio = { version = "0.2.13", features = ["full"] }
+hyper = { version = "0.14", features = ["stream", "server", "http1", "http2"] }
+tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["net"] }
 futures = "0.3"
 futures-util = "0.3"
 tower-service = "0.3"
 saphir-cookie = "0.13.2"
 http = "0.2"
-http-body = "0.3"
+http-body = "0.4"
 parking_lot = "0.11"
 regex = "1.3"
 uuid = { version = "0.8", features = ["serde", "v4"], optional = true }
-rustls = { version = "0.18", optional = true }
-tokio-rustls = { version = "0.14", optional = true }
+rustls = { version = "0.19", optional = true }
+tokio-rustls = { version = "0.22", optional = true }
 base64 = { version = "0.13", optional = true }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/saphir/examples/basic.rs
+++ b/saphir/examples/basic.rs
@@ -7,7 +7,10 @@ use futures::{
 };
 use saphir::prelude::*;
 use serde_derive::{Deserialize, Serialize};
-use tokio::sync::RwLock;
+use tokio::{
+    sync::RwLock,
+    time::{sleep, Duration},
+};
 
 // == controller == //
 
@@ -52,7 +55,7 @@ impl Controller for MagicController {
 impl MagicController {
     async fn magic_delay(&self, req: Request) -> (u16, String) {
         if let Some(delay) = req.captures().get("delay").and_then(|t| t.parse::<u64>().ok()) {
-            tokio::time::delay_for(tokio::time::Duration::from_secs(delay)).await;
+            sleep(Duration::from_secs(delay)).await;
             (200, format!("Delayed of {} secs: {}", delay, self.label))
         } else {
             (400, "Invalid timeout".to_owned())

--- a/saphir/src/body.rs
+++ b/saphir/src/body.rs
@@ -3,11 +3,10 @@
 use crate::error::SaphirError;
 use futures::{
     task::{Context, Poll},
-    Future,
+    Future, StreamExt as _,
 };
 use http::HeaderMap;
-use http_body::SizeHint;
-use hyper::body::{Body as RawBody, Buf, HttpBody};
+use hyper::body::{Body as RawBody, Buf, HttpBody, SizeHint};
 use std::pin::Pin;
 
 pub use hyper::body::Bytes;
@@ -19,7 +18,6 @@ pub use form::Form;
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub use json::Json;
 use std::ops::DerefMut;
-use tokio::stream::StreamExt;
 
 #[doc(hidden)]
 pub(crate) static mut REQUEST_BODY_BYTES_LIMIT: Option<usize> = None;
@@ -463,7 +461,7 @@ impl HttpBody for BodyInner {
     fn poll_data(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Self::Data, SaphirError>>> {
         if let BodyInner::Memory(b) = self.deref_mut() {
             if !b.is_empty() {
-                Poll::Ready(Some(Ok(b.to_bytes())))
+                Poll::Ready(Some(Ok(b.slice(..))))
             } else {
                 Poll::Ready(None)
             }

--- a/saphir/src/error.rs
+++ b/saphir/src/error.rs
@@ -7,7 +7,7 @@ use http::{
     header::{InvalidHeaderValue, ToStrError},
     Error as HttpCrateError,
 };
-use hyper::error::Error as HyperError;
+use hyper::Error as HyperError;
 use std::{
     error::Error as StdError,
     fmt::{Debug, Display, Error as FmtError, Formatter},

--- a/saphir/src/multipart/mod.rs
+++ b/saphir/src/multipart/mod.rs
@@ -32,7 +32,7 @@ pub enum MultipartError {
     AlreadyConsumed,
     MissingBoundary,
     Finished,
-    Hyper(hyper::error::Error),
+    Hyper(hyper::Error),
     Io(std::io::Error),
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]

--- a/saphir/src/server.rs
+++ b/saphir/src/server.rs
@@ -12,7 +12,6 @@ use std::{future::Future, mem::MaybeUninit, net::SocketAddr};
 use futures::{
     prelude::*,
     task::{Context, Poll},
-    StreamExt as _,
 };
 use hyper::{body::Body as RawBody, server::conn::Http, service::Service};
 use parking_lot::{Once, OnceState};


### PR DESCRIPTION
We need saphir with updated dependencies in order to build Devolutions Gateway for Windows ARM64 build (it doesn’t work if a dependency somewhere is using winapi 0.2.x).

Since Devolutions Gateway is not using mongodb, it’s okay to update tokio. However, you may want to wait for mongodb 2.x before merging this, or Lucid will have to wait before updating saphir.

Note: CI will break because of clippy lints, since I’m not sure if this PR will be merged anytime soon, I didn’t fix the new clippy warnings because you’ll probably want to merge these separately.

cc @awakecoding 