### PR TITLE
Fixed duplicate content-type for json & form

### DIFF
--- a/saphir/src/responder.rs
+++ b/saphir/src/responder.rs
@@ -145,11 +145,10 @@ mod json {
 
     impl<T: Serialize> Responder for Json<T> {
         fn respond_with_builder(self, builder: Builder, _ctx: &HttpContext) -> Builder {
-            let b = match builder.json(&self.0) {
+            match builder.json(&self.0) {
                 Ok(b) => b,
                 Err((b, _e)) => b.status(500).body("Unable to serialize json data"),
-            };
-            b.header(http::header::CONTENT_TYPE, "application/json")
+            }
         }
     }
 }
@@ -163,11 +162,10 @@ mod form {
 
     impl<T: Serialize> Responder for Form<T> {
         fn respond_with_builder(self, builder: Builder, _ctx: &HttpContext) -> Builder {
-            let b = match builder.form(&self.0) {
+            match builder.form(&self.0) {
                 Ok(b) => b,
                 Err((b, _e)) => b.status(500).body("Unable to serialize form data"),
-            };
-            b.header(http::header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+            }
         }
     }
 }


### PR DESCRIPTION
This caused some issues, notably failing newer TechEmpower benchmarks