### PR TITLE
Feature: implement `tracing` logs as a feature

### DIFF
--- a/saphir/Cargo.toml
+++ b/saphir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saphir"
-version = "3.0.3"
+version = "3.0.4"
 edition = "2021"
 authors = ["Richer Archambault <richer.arc@gmail.com>"]
 description = "Fully async-await http server framework"
@@ -37,6 +37,7 @@ operation = ["serde", "uuid"]
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
 validate-requests = ["validator", "saphir_macro/validate-requests"]
+tracing-instrument = ["tracing", "saphir_macro/tracing-instrument"]
 
 [dependencies]
 async-stream = "0.3"
@@ -53,6 +54,7 @@ regex = "1"
 uuid = { version = "0.8", features = ["serde", "v4"], optional = true }
 rustls = { version = "0.20.2", optional = true }
 rustls-pemfile = { version = "0.2", optional = true }
+tracing = { version = "0.1", optional = true, features = ["log"]}
 tokio-rustls = { version = "0.23", optional = true }
 base64 = { version = "0.13", optional = true }
 serde = { version = "1.0", optional = true }

--- a/saphir/Cargo.toml
+++ b/saphir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saphir"
-version = "3.0.4"
+version = "3.1.0"
 edition = "2021"
 authors = ["Richer Archambault <richer.arc@gmail.com>"]
 description = "Fully async-await http server framework"

--- a/saphir/src/file/middleware.rs
+++ b/saphir/src/file/middleware.rs
@@ -206,10 +206,7 @@ impl Middleware for FileMiddleware {
         #[cfg(feature = "tracing-instrument")]
         {
             use tracing::Instrument;
-            let span = tracing::span!(
-                tracing::Level::ERROR,
-                "saphir:file",
-            );
+            let span = tracing::span!(tracing::Level::ERROR, "saphir:file",);
             let span2 = span.clone();
             async move {
                 let res = self.next_inner(ctx, chain).instrument(span).await;
@@ -219,7 +216,8 @@ impl Middleware for FileMiddleware {
                     }
                     ctx
                 })
-            }.boxed()
+            }
+            .boxed()
         }
         #[cfg(not(feature = "tracing-instrument"))]
         {

--- a/saphir/src/file/middleware.rs
+++ b/saphir/src/file/middleware.rs
@@ -203,7 +203,28 @@ impl FileMiddleware {
 
 impl Middleware for FileMiddleware {
     fn next(&'static self, ctx: HttpContext, chain: &'static dyn MiddlewareChain) -> BoxFuture<'static, Result<HttpContext, SaphirError>> {
-        self.next_inner(ctx, chain).boxed()
+        #[cfg(feature = "tracing-instrument")]
+        {
+            use tracing::Instrument;
+            let span = tracing::span!(
+                tracing::Level::ERROR,
+                "saphir:file",
+            );
+            let span2 = span.clone();
+            async move {
+                let res = self.next_inner(ctx, chain).instrument(span).await;
+                res.map(|mut ctx| {
+                    if let Some(res) = ctx.state.response_mut() {
+                        res.span = Some(span2);
+                    }
+                    ctx
+                })
+            }.boxed()
+        }
+        #[cfg(not(feature = "tracing-instrument"))]
+        {
+            self.next_inner(ctx, chain).boxed()
+        }
     }
 }
 

--- a/saphir/src/file/middleware.rs
+++ b/saphir/src/file/middleware.rs
@@ -206,7 +206,7 @@ impl Middleware for FileMiddleware {
         #[cfg(feature = "tracing-instrument")]
         {
             use tracing::Instrument;
-            let span = tracing::span!(tracing::Level::ERROR, "saphir:file",);
+            let span = tracing::span!(tracing::Level::ERROR, "saphir:file");
             let span2 = span.clone();
             async move {
                 let res = self.next_inner(ctx, chain).instrument(span).await;

--- a/saphir/src/lib.rs
+++ b/saphir/src/lib.rs
@@ -122,9 +122,18 @@ pub mod server;
 ///
 pub mod utils;
 ///
+#[doc(hidden)]
+// mod tracing as tracing_utils;
+///
 pub use http;
 #[doc(hidden)]
 pub use hyper;
+#[doc(hidden)]
+pub use tracing as tokio_tracing;
+
+#[cfg(feature = "tracing-instrument")]
+#[derive(Debug)]
+pub struct RouteSpan(pub tracing::span::Span);
 
 /// Contains everything you need to bootstrap your http server
 ///

--- a/saphir/src/lib.rs
+++ b/saphir/src/lib.rs
@@ -122,18 +122,12 @@ pub mod server;
 ///
 pub mod utils;
 ///
-#[doc(hidden)]
-// mod tracing as tracing_utils;
-///
 pub use http;
 #[doc(hidden)]
 pub use hyper;
-#[doc(hidden)]
-pub use tracing as tokio_tracing;
-
 #[cfg(feature = "tracing-instrument")]
-#[derive(Debug)]
-pub struct RouteSpan(pub tracing::span::Span);
+#[doc(hidden)]
+pub use tracing;
 
 /// Contains everything you need to bootstrap your http server
 ///

--- a/saphir/src/redirect.rs
+++ b/saphir/src/redirect.rs
@@ -286,12 +286,12 @@ impl Redirect {
         self.content_type.as_ref()
     }
 
-    /// Get the cookies sent by the browsers
+    #[inline]
     pub fn cookies(&self) -> Option<&CookieJar> {
         self.cookies.as_ref()
     }
 
-    /// Get the cookies sent by the browsers in a mutable way
+    #[inline]
     pub fn cookies_mut(&mut self) -> Option<&mut CookieJar> {
         self.cookies.as_mut()
     }

--- a/saphir/src/redirect.rs
+++ b/saphir/src/redirect.rs
@@ -110,12 +110,7 @@ impl Builder {
 
     #[inline]
     pub fn cookie(mut self, cookie: Cookie<'static>) -> Builder {
-        if self.cookies.is_none() {
-            self.cookies = Some(CookieJar::new());
-        }
-
-        self.cookies.as_mut().expect("Should not happens").add(cookie);
-
+        self.cookies_mut().add(cookie);
         self
     }
 

--- a/saphir/src/responder.rs
+++ b/saphir/src/responder.rs
@@ -212,7 +212,10 @@ pub mod spanned {
         }
     }
 
-    impl<R> Responder for SpannedResponder<R> where R: Responder {
+    impl<R> Responder for SpannedResponder<R>
+    where
+        R: Responder,
+    {
         fn respond_with_builder(self, builder: Builder, ctx: &HttpContext) -> Builder {
             self.responder.respond_with_builder(builder, ctx).span(self.span)
         }

--- a/saphir/src/responder.rs
+++ b/saphir/src/responder.rs
@@ -193,3 +193,28 @@ where
         self.take().ok_or(500).respond_with_builder(builder, ctx)
     }
 }
+
+#[cfg(feature = "tracing-instrument")]
+#[doc(hidden)]
+pub mod spanned {
+    use super::*;
+
+    #[derive(Debug)]
+    pub struct SpannedResponder<R> {
+        pub responder: R,
+        span: tracing::span::Span,
+    }
+
+    impl<R> SpannedResponder<R> {
+        #[doc(hidden)]
+        pub fn new(responder: R, span: tracing::span::Span) -> Self {
+            Self { responder, span }
+        }
+    }
+
+    impl<R> Responder for SpannedResponder<R> where R: Responder {
+        fn respond_with_builder(self, builder: Builder, ctx: &HttpContext) -> Builder {
+            self.responder.respond_with_builder(builder, ctx).span(self.span)
+        }
+    }
+}

--- a/saphir/src/response.rs
+++ b/saphir/src/response.rs
@@ -19,6 +19,9 @@ pub struct Response<T = Body> {
     inner: RawResponse<T>,
     #[doc(hidden)]
     cookies: CookieJar,
+    #[cfg(feature = "tracing-instrument")]
+    #[doc(hidden)]
+    pub(crate) span: Option<tracing::span::Span>,
 }
 
 impl<T> Response<T> {
@@ -32,6 +35,7 @@ impl<T> Response<T> {
         Response {
             inner: RawResponse::new(body),
             cookies: Default::default(),
+            span: None,
         }
     }
 
@@ -60,12 +64,12 @@ impl<T> Response<T> {
     where
         F: FnOnce(T) -> U,
     {
-        let Response { inner, cookies } = self;
-        Response { inner: inner.map(f), cookies }
+        let Response { inner, cookies, span } = self;
+        Response { inner: inner.map(f), cookies, span }
     }
 
     pub(crate) fn into_raw(self) -> Result<RawResponse<T>, SaphirError> {
-        let Response { mut inner, cookies } = self;
+        let Response { mut inner, cookies, span: _ } = self;
         for c in cookies.iter() {
             inner
                 .headers_mut()
@@ -100,6 +104,9 @@ pub struct Builder {
     body: Box<dyn TransmuteBody + Send>,
     #[doc(hidden)]
     status_set: bool,
+    #[cfg(feature = "tracing-instrument")]
+    #[doc(hidden)]
+    span: Option<tracing::span::Span>,
 }
 
 impl Builder {
@@ -120,7 +127,15 @@ impl Builder {
             cookies: None,
             body: Box::new(Option::<String>::None),
             status_set: false,
+            span: None,
         }
+    }
+
+    #[cfg(feature = "tracing-instrument")]
+    #[inline]
+    pub(crate) fn span(mut self, span: tracing::span::Span) -> Builder {
+        self.span = Some(span);
+        self
     }
 
     #[inline]
@@ -327,6 +342,9 @@ impl Builder {
     /// Finish the builder into Response<Body>
     #[inline]
     pub fn build(self) -> Result<Response<Body>, SaphirError> {
+        #[cfg(feature = "tracing-instrument")]
+        let Builder { inner, cookies, mut body, span, .. } = self;
+        #[cfg(not(feature = "tracing-instrument"))]
         let Builder { inner, cookies, mut body, .. } = self;
         let b = body.transmute();
         let raw = inner.body(b)?;
@@ -334,6 +352,8 @@ impl Builder {
         Ok(Response {
             inner: raw,
             cookies: cookies.unwrap_or_default(),
+            #[cfg(feature = "tracing-instrument")]
+            span,
         })
     }
 }

--- a/saphir/src/response.rs
+++ b/saphir/src/response.rs
@@ -318,12 +318,7 @@ impl Builder {
     /// ```
     #[inline]
     pub fn cookie(mut self, cookie: Cookie<'static>) -> Builder {
-        if self.cookies.is_none() {
-            self.cookies = Some(CookieJar::new());
-        }
-
-        self.cookies.as_mut().expect("Should not happens").add(cookie);
-
+        self.cookies_mut().add(cookie);
         self
     }
 

--- a/saphir/src/response.rs
+++ b/saphir/src/response.rs
@@ -338,6 +338,12 @@ impl Builder {
     }
 
     #[inline]
+    pub fn cookies(mut self, cookies: CookieJar) -> Builder {
+        self.cookies = Some(cookies);
+        self
+    }
+
+    #[inline]
     pub fn body<B: 'static + Into<RawBody> + Send>(mut self, body: B) -> Builder {
         self.body = Box::new(Some(body));
         self

--- a/saphir/src/utils.rs
+++ b/saphir/src/utils.rs
@@ -558,7 +558,6 @@ where
     serde_urlencoded::from_str::<T>(query_str)
 }
 
-
 // #[cfg(feature = "tracing-instrument")]
 // #[derive(Debug, Clone, Serialize, Deserialize)]
 // pub struct SaphirRequestSpan(::tracing::span::Span);

--- a/saphir/src/utils.rs
+++ b/saphir/src/utils.rs
@@ -558,10 +558,6 @@ where
     serde_urlencoded::from_str::<T>(query_str)
 }
 
-// #[cfg(feature = "tracing-instrument")]
-// #[derive(Debug, Clone, Serialize, Deserialize)]
-// pub struct SaphirRequestSpan(::tracing::span::Span);
-
 #[cfg(test)]
 mod tests {
     use super::{EndpointResolver, Method};

--- a/saphir/src/utils.rs
+++ b/saphir/src/utils.rs
@@ -558,6 +558,11 @@ where
     serde_urlencoded::from_str::<T>(query_str)
 }
 
+
+// #[cfg(feature = "tracing-instrument")]
+// #[derive(Debug, Clone, Serialize, Deserialize)]
+// pub struct SaphirRequestSpan(::tracing::span::Span);
+
 #[cfg(test)]
 mod tests {
     use super::{EndpointResolver, Method};

--- a/saphir_cli/src/openapi/generate/crate_syn_browser/module.rs
+++ b/saphir_cli/src/openapi/generate/crate_syn_browser/module.rs
@@ -52,7 +52,7 @@ impl<'b> UseScope<'b> for Module<'b> {
         let split: Vec<&str> = name.split("::").collect();
         let split_len = split.len();
         if split_len > 1 {
-            let mod_path: String = (&split[..(split_len - 1)]).join("::");
+            let mod_path: String = split[..(split_len - 1)].join("::");
             let mod_path = self.expand_path(mod_path.as_str());
             let last = split.last().expect("bound checked above");
             if let Some(module) = self.target().module_by_use_path(mod_path.as_str())? {

--- a/saphir_cli/src/openapi/generate/route_info.rs
+++ b/saphir_cli/src/openapi/generate/route_info.rs
@@ -44,7 +44,7 @@ impl Gen {
     ) -> Option<RouteInfo> {
         let mut full_path = format!("/{}{}", controller_path, path);
         if full_path.ends_with('/') {
-            full_path = (&full_path[0..(full_path.len() - 1)]).to_string();
+            full_path = full_path[0..(full_path.len() - 1)].to_string();
         }
         if !full_path.starts_with(self.args.scope.as_str()) {
             return None;
@@ -89,7 +89,7 @@ impl Gen {
                         for j in start..chars.len() {
                             if chars[j] == '>' || chars[j] == '}' {
                                 chars[j] = '}';
-                                params.push((&chars[(i + 1)..j]).iter().collect());
+                                params.push(chars[(i + 1)..j].iter().collect());
                                 i = j;
                                 break;
                             }

--- a/saphir_macro/Cargo.toml
+++ b/saphir_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saphir_macro"
-version = "2.1.4"
+version = "2.2.0"
 authors = ["Richer Archambault <richer.arc@gmail.com>"]
 edition = "2021"
 description = "Macro generation for http server framework"

--- a/saphir_macro/Cargo.toml
+++ b/saphir_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "saphir_macro"
-version = "2.1.3"
+version = "2.1.4"
 authors = ["Richer Archambault <richer.arc@gmail.com>"]
 edition = "2021"
 description = "Macro generation for http server framework"
@@ -20,6 +20,7 @@ proc-macro = true
 default = []
 full = ["validate-requests"]
 validate-requests = []
+tracing-instrument = []
 
 [dependencies]
 proc-macro2 = "1.0"


### PR DESCRIPTION
the request tracing is integrated into the handler code instead of as a middleware to be able to wrap the FileMiddleware log span within the request span regardless of middleware order.

This PR also fix controller macro's handler span so that tracing span within the macro output have proper line numbers, instead of pointing to the top #[controller] macro.